### PR TITLE
fix : dev환경 redis 도커 컨테이너 연결

### DIFF
--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -16,7 +16,7 @@ spring:
       password: password
   data:
     redis:
-      host: localhost
+      host: yapp_redis
       port: 6379
 
 token:


### PR DESCRIPTION
## 😋 작업한 내용

- dev 환경에서 도커 컨테이너끼리 연동할려면 yml에서 host를 redis 컨테이너 이름으로 해야함

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #83


---