### PR TITLE
fix : 아티스트 구독하지 않은 목록 인증/인가 수정

### DIFF
--- a/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
+++ b/app/api/common-api/src/main/java/org/example/config/SecurityConfig.java
@@ -78,7 +78,8 @@ public class SecurityConfig {
             antMatcher(HttpMethod.GET, "/api/v1/artists/search/**"),
             antMatcher(HttpMethod.GET, "/api/v1/shows/search/**"),
             antMatcher(HttpMethod.GET, "/api/v1/artists/filter"),
-            antMatcher(HttpMethod.GET, "/api/v1/artists/filter-total-count")
+            antMatcher(HttpMethod.GET, "/api/v1/artists/filter-total-count"),
+            antMatcher(HttpMethod.GET, "/api/v1/artists/unsubscriptions")
         );
     }
 
@@ -96,8 +97,7 @@ public class SecurityConfig {
             antMatcher(HttpMethod.GET, "/api/v1/genres/unsubscriptions"),
             antMatcher(HttpMethod.POST, "/api/v1/artists/subscribe"),
             antMatcher(HttpMethod.POST, "/api/v1/artists/unsubscribe"),
-            antMatcher(HttpMethod.GET, "/api/v1/artists/subscriptions"),
-            antMatcher(HttpMethod.GET, "/api/v1/artists/unsubscriptions")
+            antMatcher(HttpMethod.GET, "/api/v1/artists/subscriptions")
         );
     }
 }

--- a/app/api/show-api/src/main/java/com/example/artist/controller/ArtistController.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/ArtistController.java
@@ -42,8 +42,15 @@ public class ArtistController {
         @AuthenticationPrincipal AuthenticatedUser user,
         @ParameterObject ArtistUnsubscriptionPaginationApiRequest request
     ) {
-        var response = artistService.findArtistUnsubscriptions(
-            request.toServiceRequest(user.userId()));
+        var response =
+            (user == null)
+                ? artistService.findArtistUnsubscriptionsForNonUser(
+                    request.toNonUserServiceRequest()
+                )
+                : artistService.findArtistUnsubscriptions(
+                    request.toServiceRequest(user.userId())
+                );
+
         var data = response.data().stream()
             .map(ArtistUnsubscriptionPaginationApiParam::from)
             .toList();

--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/request/ArtistUnsubscriptionPaginationApiRequest.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/request/ArtistUnsubscriptionPaginationApiRequest.java
@@ -65,4 +65,17 @@ public record ArtistUnsubscriptionPaginationApiRequest(
             .size(size)
             .build();
     }
+
+    public ArtistUnsubscriptionPaginationServiceRequest toNonUserServiceRequest() {
+        return ArtistUnsubscriptionPaginationServiceRequest.builder()
+            .subscriptionStatusApiType(SubscriptionStatusApiType.UNSUBSCRIBED)
+            .sortStandard(sortStandard)
+            .artistGenderApiTypes(artistGenderApiTypes)
+            .artistApiTypes(artistApiTypes)
+            .genreIds(genreIds)
+            .userId(null)
+            .cursor(cursor)
+            .size(size)
+            .build();
+    }
 }

--- a/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
@@ -144,6 +144,18 @@ public class ArtistService {
         return PaginationServiceResponse.of(data, response.hasNext());
     }
 
+    public PaginationServiceResponse<ArtistUnsubscriptionPaginationServiceParam> findArtistUnsubscriptionsForNonUser(
+        ArtistUnsubscriptionPaginationServiceRequest request
+    ) {
+        var response = artistUseCase.findAllArtistInCursorPagination(
+            request.toNonUserDomainRequest());
+        List<ArtistUnsubscriptionPaginationServiceParam> data = response.data().stream()
+            .map(ArtistUnsubscriptionPaginationServiceParam::new)
+            .toList();
+
+        return PaginationServiceResponse.of(data, response.hasNext());
+    }
+
     private List<UUID> getSubscriptionArtistIds(UUID userId) {
         List<ArtistSubscription> subscriptions = artistSubscriptionUseCase.findSubscriptionList(
             userId);

--- a/app/api/show-api/src/main/java/com/example/artist/service/dto/request/ArtistUnsubscriptionPaginationServiceRequest.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/dto/request/ArtistUnsubscriptionPaginationServiceRequest.java
@@ -23,6 +23,14 @@ public record ArtistUnsubscriptionPaginationServiceRequest(
 ) {
 
     public ArtistPaginationDomainRequest toDomainRequest(List<UUID> artistIds) {
+        return buildDomainRequest(artistIds);
+    }
+
+    public ArtistPaginationDomainRequest toNonUserDomainRequest() {
+        return buildDomainRequest(List.of());
+    }
+
+    private ArtistPaginationDomainRequest buildDomainRequest(List<UUID> artistIds) {
         var artistGenders = artistGenderApiTypes.stream()
             .map(ArtistGenderApiType::toDomainType)
             .toList();

--- a/app/api/show-api/src/test/java/artist/service/ArtistServiceTest.java
+++ b/app/api/show-api/src/test/java/artist/service/ArtistServiceTest.java
@@ -443,4 +443,31 @@ class ArtistServiceTest {
             }
         );
     }
+
+    @Test
+    @DisplayName("페이지네이션을 이용해 비회원도 구독하지 않은 아티스트를 조회할 수 있다.")
+    void artistUnsubscribeForNonUserWithPagination() {
+        //given
+        int size = 2;
+        boolean hasNext = true;
+        var request = ArtistRequestDtoFixture.artistUnsubscriptionPaginationServiceRequest(size);
+
+        given(
+            artistUseCase.findAllArtistInCursorPagination(
+                request.toNonUserDomainRequest())
+        ).willReturn(
+            ArtistResponseDtoFixture.artistPaginationDomainResponse(size, hasNext)
+        );
+
+        //when
+        var result = artistService.findArtistUnsubscriptionsForNonUser(request);
+
+        //then
+        SoftAssertions.assertSoftly(
+            soft -> {
+                soft.assertThat(result.data().size()).isEqualTo(size);
+                soft.assertThat(result.hasNext()).isEqualTo(hasNext);
+            }
+        );
+    }
 }


### PR DESCRIPTION
## 😋 작업한 내용

- 아티스트 구독하지 않은 목록을 토큰이 있어야만 API 요청이 가능했는데, 요구사항대로 홈 화면에서 비회원도 조회가능하도록 수정했습니다.

## 🙏 PR Point

- 말씀하신대로 controller에서 user을 확인하고 분기하여 service를 2개로 분할하였습니다!
- dto는 필드 값만 변경하고 재사용했습니다!

## 👍 관련 이슈

- Resolved : #77


---