### PR TITLE
fix : docker compose dev

### DIFF
--- a/.github/workflows/showpot-dev-cd.yml
+++ b/.github/workflows/showpot-dev-cd.yml
@@ -38,7 +38,7 @@ jobs:
           spring.datasource.password: ${{ secrets.APPLICATION_DATASOURCE_PASSWORD }}
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew clean build
+        run: ./gradlew clean build -Dspring.profiles.active=dev
 
       - name: Prepare File for Deployment
         run: |

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,14 +1,7 @@
 services:
-  redis:
-    container_name: yapp_redis
-    image: redis:alpine
-    ports:
-      - '6379:6379'
-    networks:
-      - app-network
-
   app:
     image: yapp
+    container_name: yapp_core
     build:
       context: .
       dockerfile: dockerfile-dev
@@ -17,10 +10,9 @@ services:
       SPRING_REDIS_PORT: 6379
     ports:
       - '8080:8080'
-    depends_on:
-      - redis
     networks:
       - app-network
 
 networks:
   app-network:
+    driver: bridge


### PR DESCRIPTION
## 😋 작업한 내용

- docker-compose-dev.yml 수정

## 🙏 PR Point

코어 서버와 알림 서버는 둘다 레디스를 사용함
둘의 cd에 따라 레디스가 계속 새로 띄워지며, 해당 앱 컨테이너가 띄워지면 다른 앱 컨테이너가 죽어버림
따라서 ec2에 레디스 컨테이너는 계속 켜진 상태로 납두고, cd는 애플리케이션 컨테이너만 띄우게 함
네트워크는 일치시킴

## 👍 관련 이슈

- Resolved : #96 


---