### PR TITLE
fix : 레디스 네트워크 연동

### DIFF
--- a/.github/workflows/showpot-dev-cd.yml
+++ b/.github/workflows/showpot-dev-cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - hotfix/**
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/showpot-dev-cd.yml
+++ b/.github/workflows/showpot-dev-cd.yml
@@ -38,7 +38,7 @@ jobs:
           spring.datasource.password: ${{ secrets.APPLICATION_DATASOURCE_PASSWORD }}
 
       - name: Build with Gradle Wrapper
-        run: ./gradlew clean build
+        run: ./gradlew clean build -Dspring.profiles.active=dev
 
       - name: Prepare File for Deployment
         run: |

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -16,7 +16,7 @@ spring:
       password: password
   data:
     redis:
-      host: yapp_redis
+      host: redis
       port: 6379
 
 token:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,14 +1,7 @@
 services:
-  redis:
-    container_name: yapp_redis
-    image: redis:alpine
-    ports:
-      - '6379:6379'
-    networks:
-      - app-network
-
   app:
     image: yapp
+    container_name: yapp_core
     build:
       context: .
       dockerfile: dockerfile-dev
@@ -17,10 +10,9 @@ services:
       SPRING_REDIS_PORT: 6379
     ports:
       - '8080:8080'
-    depends_on:
-      - redis
     networks:
       - app-network
 
 networks:
   app-network:
+    driver: bridge

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,7 @@ services:
     networks:
       - yapp-network
     depends_on:
-      - redis정
+      - redis
 
 networks:
   yapp-network:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -11,8 +11,10 @@ services:
     ports:
       - '8080:8080'
     networks:
-      - app-network
+      - yapp-network
+    depends_on:
+      - redis정
 
 networks:
-  app-network:
-    driver: bridge
+  yapp-network:
+    external: true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,8 +12,6 @@ services:
       - '8080:8080'
     networks:
       - yapp-network
-    depends_on:
-      - redis
 
 networks:
   yapp-network:


### PR DESCRIPTION
## 😋 작업한 내용

- ec2 내부의 도커 컨테이너간 네트워크가 연결이 안되는 오류가 있었어요.
- ec2 내부에 도커 네트워크 yapp-network를 만들고, docker-compose-dev.yml에서 yapp-network 네트워크를 사용하도록 했습니다. 
- docker inspect redis --format='{{json .NetworkSettings.Networks}}' 이 명령어 치면 
`
{"yapp-network":{"IPAMConfig":null,"Links":null,"Aliases":["redis","e0b4fd0b7eb4"],"MacAddress":"02:42:ac:17:00:02","NetworkID":"7484d3c8b7fbe8ef38853a3a91a0b735999b27fecc35d6db38b7ee5652863565","EndpointID":"051eb491c0e7871682f0c482f945bd14b2da61b382198ddc23c062bc5e5a7d60","Gateway":"172.23.0.1","IPAddress":"172.23.0.2","IPPrefixLen":16,"IPv6Gateway":"","GlobalIPv6Address":"","GlobalIPv6PrefixLen":0,"DriverOpts":null,"DNSNames":["redis","e0b4fd0b7eb4"]}}`
이렇게 나와용

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #96 


---