### PR TITLE
fix: 공연 업데이트 오류 문제 

### DIFF
--- a/app/api/common-api/src/main/java/org/example/error/GlobalExceptionHandler.java
+++ b/app/api/common-api/src/main/java/org/example/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.example.error;
 
 import jakarta.validation.ConstraintViolationException;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.example.exception.BusinessException;
@@ -38,6 +39,21 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.businessErrorResponseBuilder()
             .errorId(errorId)
             .error(e.error)
+            .build();
+
+        log.error(errorId, e);
+
+        return ResponseEntity.status(response.httpStatus())
+            .body(response);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    protected ResponseEntity<ErrorResponse> handleNoSuchElementException(final NoSuchElementException e) {
+        String errorId = UUID.randomUUID().toString();
+        ErrorResponse response = ErrorResponse.messageCustomErrorResponseBuilder()
+            .errorId(errorId)
+            .message(GlobalError.ELEMENT_NOT_FOUND.getClientMessage())
+            .error(GlobalError.ELEMENT_NOT_FOUND)
             .build();
 
         log.error(errorId, e);

--- a/app/api/show-api/src/main/java/com/example/artist/service/ArtistAdminService.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/ArtistAdminService.java
@@ -1,19 +1,15 @@
 package com.example.artist.service;
 
-import com.example.artist.error.ArtistError;
 import com.example.artist.service.dto.request.ArtistCreateServiceRequest;
 import com.example.artist.service.dto.request.ArtistUpdateServiceRequest;
 import com.example.artist.service.dto.response.ArtistDetailServiceResponse;
 import com.example.artist.service.dto.response.ArtistKoreanNameServiceResponse;
-import com.example.artist.service.dto.response.ArtistKoreanNameWithShowIdServiceResponse;
 import com.example.component.FileUploadComponent;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.example.dto.artist.response.ArtistDetailDomainResponse;
 import org.example.entity.artist.Artist;
-import org.example.exception.BusinessException;
 import org.example.usecase.artist.ArtistUseCase;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +23,7 @@ public class ArtistAdminService {
     public void save(ArtistCreateServiceRequest artistCreateServiceRequest) {
         String imageUrl = fileUploadComponent.uploadFile("artists", artistCreateServiceRequest.image());
         Artist artist = artistCreateServiceRequest.toArtistWithImageUrl(imageUrl);
+
         artistUseCase.save(artist, artistCreateServiceRequest.genreIds());
     }
 
@@ -42,39 +39,22 @@ public class ArtistAdminService {
             .toList();
     }
 
-    public List<ArtistKoreanNameWithShowIdServiceResponse> findArtistKoreanNamesWithShowId() {
-        return artistUseCase.findArtistKoreanNamesWithShowId().stream()
-            .map(ArtistKoreanNameWithShowIdServiceResponse::from)
-            .toList();
-    }
-
     public ArtistDetailServiceResponse findArtistById(UUID id) {
         ArtistDetailDomainResponse response;
-        try {
-            response = artistUseCase.findArtistDetailById(id);
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(ArtistError.ENTITY_NOT_FOUND);
-        }
+        response = artistUseCase.findArtistDetailById(id);
 
         return new ArtistDetailServiceResponse(response);
     }
 
     public void updateArtist(UUID id, ArtistUpdateServiceRequest artistUpdateServiceRequest) {
-        String imageUrl = fileUploadComponent.uploadFile("artist", artistUpdateServiceRequest.image());
+        String imageUrl = fileUploadComponent.uploadFile("artist",
+            artistUpdateServiceRequest.image());
         Artist artist = artistUpdateServiceRequest.toArtist(imageUrl);
 
-        try {
-            artistUseCase.updateArtist(id, artist, artistUpdateServiceRequest.genreIds());
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(ArtistError.ENTITY_NOT_FOUND);
-        }
+        artistUseCase.updateArtist(id, artist, artistUpdateServiceRequest.genreIds());
     }
 
     public void deleteArtist(UUID id) {
-        try {
-            artistUseCase.deleteArtist(id);
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(ArtistError.ENTITY_NOT_FOUND);
-        }
+        artistUseCase.deleteArtist(id);
     }
 }

--- a/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
@@ -15,7 +15,6 @@ import com.example.artist.service.dto.response.ArtistUnsubscriptionServiceRespon
 import com.example.publish.MessagePublisher;
 import com.example.publish.message.ArtistSubscriptionServiceMessage;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.example.dto.response.PaginationServiceResponse;
@@ -53,14 +52,10 @@ public class ArtistService {
     ) {
         List<UUID> subscriptionArtistIds = getSubscriptionArtistIds(request.userId());
 
-        try {
-            return new ArtistFilterTotalCountServiceResponse(
-                artistUseCase.findFilterArtistTotalCount(
-                    request.toDomainRequest(subscriptionArtistIds))
-            );
-        } catch (NoSuchElementException e) {
-            return ArtistFilterTotalCountServiceResponse.noneTotalCount();
-        }
+        return new ArtistFilterTotalCountServiceResponse(
+            artistUseCase.findFilterArtistTotalCount(
+                request.toDomainRequest(subscriptionArtistIds))
+        );
     }
 
     public ArtistSubscriptionServiceResponse subscribe(ArtistSubscriptionServiceRequest request) {

--- a/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
@@ -15,6 +15,7 @@ import com.example.artist.service.dto.response.ArtistUnsubscriptionServiceRespon
 import com.example.publish.MessagePublisher;
 import com.example.publish.message.ArtistSubscriptionServiceMessage;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.example.dto.response.PaginationServiceResponse;
@@ -52,10 +53,15 @@ public class ArtistService {
     ) {
         List<UUID> subscriptionArtistIds = getSubscriptionArtistIds(request.userId());
 
-        return new ArtistFilterTotalCountServiceResponse(
-            artistUseCase.findFilterArtistTotalCount(
-                request.toDomainRequest(subscriptionArtistIds))
-        );
+        try {
+            return new ArtistFilterTotalCountServiceResponse(
+                artistUseCase.findFilterArtistTotalCount(
+                    request.toDomainRequest(subscriptionArtistIds)
+                )
+            );
+        } catch (NoSuchElementException e) {
+            return ArtistFilterTotalCountServiceResponse.noneTotalCount();
+        }
     }
 
     public ArtistSubscriptionServiceResponse subscribe(ArtistSubscriptionServiceRequest request) {

--- a/app/api/show-api/src/main/java/com/example/genre/service/GenreAdminService.java
+++ b/app/api/show-api/src/main/java/com/example/genre/service/GenreAdminService.java
@@ -1,16 +1,12 @@
 package com.example.genre.service;
 
-import com.example.genre.error.GenreError;
 import com.example.genre.service.dto.request.GenreCreateServiceRequest;
 import com.example.genre.service.dto.request.GenreUpdateServiceRequest;
 import com.example.genre.service.dto.response.GenreNameServiceResponse;
-import com.example.genre.service.dto.response.GenreNameWithShowIdServiceResponse;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.example.entity.genre.Genre;
-import org.example.exception.BusinessException;
 import org.example.usecase.genre.GenreUseCase;
 import org.springframework.stereotype.Service;
 
@@ -24,12 +20,6 @@ public class GenreAdminService {
         genreUseCase.save(genreCreateServiceRequest.toGenre());
     }
 
-    public List<GenreNameWithShowIdServiceResponse> findGenreNamesWithShowId() {
-        return genreUseCase.findGenreNamesWithShowId().stream()
-            .map(GenreNameWithShowIdServiceResponse::new)
-            .toList();
-    }
-
     public List<GenreNameServiceResponse> findAllGenres() {
         List<Genre> genres = genreUseCase.findAllGenres();
         return genres.stream()
@@ -38,28 +28,15 @@ public class GenreAdminService {
     }
 
     public void updateGenre(UUID id, GenreUpdateServiceRequest genreUpdateServiceRequest) {
-        try {
-            genreUseCase.updateGenre(id, genreUpdateServiceRequest.name());
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(GenreError.ENTITY_NOT_FOUND);
-        }
+        genreUseCase.updateGenre(id, genreUpdateServiceRequest.name());
     }
 
     public void deleteGenre(UUID id) {
-        try {
-            genreUseCase.deleteGenre(id);
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(GenreError.ENTITY_NOT_FOUND);
-        }
+        genreUseCase.deleteGenre(id);
     }
 
     public GenreNameServiceResponse findGenreById(UUID id) {
-        Genre genre;
-        try {
-            genre = genreUseCase.findGenreById(id);
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(GenreError.ENTITY_NOT_FOUND);
-        }
+        Genre genre = genreUseCase.findGenreById(id);
 
         return new GenreNameServiceResponse(genre.getId(), genre.getName());
     }

--- a/app/api/show-api/src/main/java/com/example/show/service/ShowAdminService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/ShowAdminService.java
@@ -4,16 +4,13 @@ package com.example.show.service;
 import com.example.component.FileUploadComponent;
 import com.example.publish.MessagePublisher;
 import com.example.publish.message.ShowRelationArtistAndGenreServiceMessage;
-import com.example.show.error.ShowError;
 import com.example.show.service.dto.request.ShowCreateServiceRequest;
 import com.example.show.service.dto.request.ShowUpdateServiceRequest;
 import com.example.show.service.dto.response.ShowInfoServiceResponse;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.example.dto.show.response.ShowInfoDomainResponse;
-import org.example.exception.BusinessException;
 import org.example.usecase.artist.ArtistUseCase;
 import org.example.usecase.genre.GenreUseCase;
 import org.example.usecase.show.ShowAdminUseCase;
@@ -59,12 +56,7 @@ public class ShowAdminService {
     }
 
     public ShowInfoServiceResponse findShowInfo(UUID id) {
-        ShowInfoDomainResponse showInfoDomainResponse;
-        try {
-            showInfoDomainResponse = showAdminUseCase.findShowInfo(id);
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(ShowError.ENTITY_NOT_FOUND);
-        }
+        ShowInfoDomainResponse showInfoDomainResponse = showAdminUseCase.findShowInfo(id);
 
         return new ShowInfoServiceResponse(showInfoDomainResponse);
     }
@@ -99,10 +91,6 @@ public class ShowAdminService {
     }
 
     public void deleteShow(UUID id) {
-        try {
-            showAdminUseCase.deleteShow(id);
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(ShowError.ENTITY_NOT_FOUND);
-        }
+        showAdminUseCase.deleteShow(id);
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/service/ShowAdminService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/ShowAdminService.java
@@ -16,14 +16,14 @@ import org.example.dto.show.response.ShowInfoDomainResponse;
 import org.example.exception.BusinessException;
 import org.example.usecase.artist.ArtistUseCase;
 import org.example.usecase.genre.GenreUseCase;
-import org.example.usecase.show.ShowUseCase;
+import org.example.usecase.show.ShowAdminUseCase;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ShowAdminService {
 
-    private final ShowUseCase showUseCase;
+    private final ShowAdminUseCase showAdminUseCase;
     private final GenreUseCase genreUseCase;
     private final ArtistUseCase artistUseCase;
     private final FileUploadComponent fileUploadComponent;
@@ -32,7 +32,7 @@ public class ShowAdminService {
     public void save(ShowCreateServiceRequest showCreateServiceRequest) {
         String imageURL = fileUploadComponent.uploadFile("show", showCreateServiceRequest.post());
 
-        showUseCase.save(
+        showAdminUseCase.save(
             showCreateServiceRequest.toDomainRequest(imageURL)
         );
 
@@ -46,7 +46,7 @@ public class ShowAdminService {
     }
 
     public List<ShowInfoServiceResponse> findShowDetailWithTicketingTimes() {
-        var showWithTicketingTimesDomainResponses = showUseCase.findShowDetailWithTicketingTimes();
+        var showWithTicketingTimesDomainResponses = showAdminUseCase.findShowDetailWithTicketingTimes();
         var artistKoreanNameWithShowIdDomainResponses = artistUseCase.findArtistKoreanNamesWithShowId();
         var genreNameWithShowIdDomainResponses = genreUseCase.findGenreNamesWithShowId();
 
@@ -61,7 +61,7 @@ public class ShowAdminService {
     public ShowInfoServiceResponse findShowInfo(UUID id) {
         ShowInfoDomainResponse showInfoDomainResponse;
         try {
-            showInfoDomainResponse = showUseCase.findShowInfo(id);
+            showInfoDomainResponse = showAdminUseCase.findShowInfo(id);
         } catch (NoSuchElementException e) {
             throw new BusinessException(ShowError.ENTITY_NOT_FOUND);
         }
@@ -72,17 +72,17 @@ public class ShowAdminService {
     public void updateShow(UUID id, ShowUpdateServiceRequest showUpdateServiceRequest) {
         String imageUrl = fileUploadComponent.uploadFile("show", showUpdateServiceRequest.post());
 
-        var artistIdsToPublish = showUseCase.getArtistIdsToAdd(
+        var artistIdsToPublish = showAdminUseCase.getArtistIdsToAdd(
             showUpdateServiceRequest.artistIds(),
-            showUseCase.findShowArtistsByShowId(id)
+            showAdminUseCase.findShowArtistsByShowId(id)
         );
 
-        var genreIdsToPublish = showUseCase.getGenreIdsToAdd(
+        var genreIdsToPublish = showAdminUseCase.getGenreIdsToAdd(
             showUpdateServiceRequest.genreIds(),
-            showUseCase.findShowGenresByShowId(id)
+            showAdminUseCase.findShowGenresByShowId(id)
         );
 
-        showUseCase.updateShow(
+        showAdminUseCase.updateShow(
             id,
             showUpdateServiceRequest.toDomainRequest(imageUrl)
         );
@@ -100,7 +100,7 @@ public class ShowAdminService {
 
     public void deleteShow(UUID id) {
         try {
-            showUseCase.deleteShow(id);
+            showAdminUseCase.deleteShow(id);
         } catch (NoSuchElementException e) {
             throw new BusinessException(ShowError.ENTITY_NOT_FOUND);
         }

--- a/app/api/show-api/src/main/java/com/example/show/service/ShowAdminService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/ShowAdminService.java
@@ -82,14 +82,10 @@ public class ShowAdminService {
             showUseCase.findShowGenresByShowId(id)
         );
 
-        try {
-            showUseCase.updateShow(
-                id,
-                showUpdateServiceRequest.toDomainRequest(imageUrl)
-            );
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(ShowError.ENTITY_NOT_FOUND);
-        }
+        showUseCase.updateShow(
+            id,
+            showUpdateServiceRequest.toDomainRequest(imageUrl)
+        );
 
         if (!artistIdsToPublish.isEmpty() || !genreIdsToPublish.isEmpty()) {
             messagePublisher.publishShow(

--- a/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
@@ -3,7 +3,6 @@ package com.example.show.service;
 import com.example.publish.MessagePublisher;
 import com.example.publish.message.TicketingAlertsToReserveServiceMessage;
 import com.example.show.controller.vo.TicketingApiType;
-import com.example.show.error.ShowError;
 import com.example.show.service.dto.param.ShowAlertPaginationServiceParam;
 import com.example.show.service.dto.param.ShowSearchPaginationServiceParam;
 import com.example.show.service.dto.request.InterestShowPaginationServiceRequest;
@@ -23,7 +22,6 @@ import com.example.show.service.dto.response.TicketingAlertReservationStatusServ
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +32,6 @@ import org.example.entity.InterestShow;
 import org.example.entity.TicketingAlert;
 import org.example.entity.show.Show;
 import org.example.entity.show.ShowTicketingTime;
-import org.example.exception.BusinessException;
 import org.example.usecase.TicketingAlertUseCase;
 import org.example.usecase.UserShowUseCase;
 import org.example.usecase.show.ShowUseCase;
@@ -51,12 +48,7 @@ public class ShowService {
 
 
     public ShowDetailServiceResponse getShow(UUID id) {
-        ShowDetailDomainResponse showDetail;
-        try {
-            showDetail = showUseCase.findShowDetail(id);
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(ShowError.ENTITY_NOT_FOUND);
-        }
+        ShowDetailDomainResponse showDetail = showUseCase.findShowDetail(id);
 
         return ShowDetailServiceResponse.from(showDetail);
     }

--- a/app/api/show-api/src/test/java/show/service/ShowAdminServiceTest.java
+++ b/app/api/show-api/src/test/java/show/service/ShowAdminServiceTest.java
@@ -22,21 +22,21 @@ import org.example.fixture.domain.ShowArtistFixture;
 import org.example.fixture.domain.ShowGenreFixture;
 import org.example.usecase.artist.ArtistUseCase;
 import org.example.usecase.genre.GenreUseCase;
-import org.example.usecase.show.ShowUseCase;
+import org.example.usecase.show.ShowAdminUseCase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import show.fixture.dto.ShowRequestDtoFixture;
 
 class ShowAdminServiceTest {
 
-    private final ShowUseCase showUseCase = mock(ShowUseCase.class);
+    private final ShowAdminUseCase showAdminUseCase = mock(ShowAdminUseCase.class);
     private final GenreUseCase genreUseCase = mock(GenreUseCase.class);
     private final ArtistUseCase artistUseCase = mock(ArtistUseCase.class);
     private final FileUploadComponent fileUploadComponent = mock(FileUploadComponent.class);
     private final MessagePublisher messagePublisher = mock(MessagePublisher.class);
 
     private final ShowAdminService showAdminService = new ShowAdminService(
-        showUseCase,
+        showAdminUseCase,
         genreUseCase,
         artistUseCase,
         fileUploadComponent,
@@ -59,7 +59,7 @@ class ShowAdminServiceTest {
         showAdminService.save(showCreateServiceRequest);
 
         //then
-        verify(showUseCase, times(1)).save(any());
+        verify(showAdminUseCase, times(1)).save(any());
     }
 
     @Test
@@ -70,7 +70,7 @@ class ShowAdminServiceTest {
         var showCreationDomainRequest = showCreateServiceRequest.toDomainRequest(
             "test_imageUrl"
         );
-        willDoNothing().given(showUseCase).save(showCreationDomainRequest);
+        willDoNothing().given(showAdminUseCase).save(showCreationDomainRequest);
 
         //when
         showAdminService.save(showCreateServiceRequest);
@@ -99,7 +99,7 @@ class ShowAdminServiceTest {
         showAdminService.updateShow(showId, showUpdateServiceRequest);
 
         //then
-        verify(showUseCase, times(1)).updateShow(eq(showId), any(ShowUpdateDomainRequest.class));
+        verify(showAdminUseCase, times(1)).updateShow(eq(showId), any(ShowUpdateDomainRequest.class));
     }
 
     @Test
@@ -110,12 +110,12 @@ class ShowAdminServiceTest {
         UUID showId = UUID.randomUUID();
         var showArtists = ShowArtistFixture.showArtists(3);
         given(
-            showUseCase.findShowArtistsByShowId(showId)
+            showAdminUseCase.findShowArtistsByShowId(showId)
         ).willReturn(
             showArtists
         );
         given(
-            showUseCase.getArtistIdsToAdd(
+            showAdminUseCase.getArtistIdsToAdd(
                 showUpdateServiceRequest.artistIds(),
                 showArtists
             )
@@ -123,12 +123,12 @@ class ShowAdminServiceTest {
 
         var showGenres = ShowGenreFixture.showGenres(3);
         given(
-            showUseCase.findShowGenresByShowId(showId)
+            showAdminUseCase.findShowGenresByShowId(showId)
         ).willReturn(
             showGenres
         );
         given(
-            showUseCase.getGenreIdsToAdd(
+            showAdminUseCase.getGenreIdsToAdd(
                 showUpdateServiceRequest.genreIds(),
                 showGenres
             )

--- a/app/api/user-api/src/main/java/org/example/service/UserService.java
+++ b/app/api/user-api/src/main/java/org/example/service/UserService.java
@@ -7,8 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.example.dto.response.UserProfileDomainResponse;
 import org.example.entity.SocialLogin;
 import org.example.entity.User;
-import org.example.error.UserError;
-import org.example.exception.BusinessException;
 import org.example.security.dto.TokenParam;
 import org.example.security.dto.UserParam;
 import org.example.security.token.JWTGenerator;
@@ -44,11 +42,7 @@ public class UserService {
     }
 
     public void withdraw(WithdrawalServiceRequest request) {
-        try {
-            userUseCase.deleteUser(request.userId());
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(UserError.NOT_FOUND_USER);
-        }
+        userUseCase.deleteUser(request.userId());
 
         tokenProcessor.makeAccessTokenBlacklistAndDeleteRefreshToken(
             request.accessToken(),
@@ -61,12 +55,7 @@ public class UserService {
     }
 
     public UserProfileServiceResponse findUserProfile(UUID userId) {
-        UserProfileDomainResponse profile;
-        try {
-            profile = userUseCase.findUserProfile(userId);
-        } catch (NoSuchElementException e) {
-            throw new BusinessException(UserError.NOT_FOUND_USER);
-        }
+        UserProfileDomainResponse profile = userUseCase.findUserProfile(userId);
 
         return UserProfileServiceResponse.from(profile);
     }

--- a/app/domain/show-domain/src/main/java/org/example/dto/show/request/ShowUpdateDomainRequest.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/show/request/ShowUpdateDomainRequest.java
@@ -32,6 +32,7 @@ public record ShowUpdateDomainRequest(
             .endDate(endDate)
             .location(location)
             .image(posterImageURL)
+            .lastTicketingAt(showTicketingTimes.getLastTicketingDateTime())
             .seatPrices(showSeats)
             .ticketingSites(showTicketingSites)
             .build();

--- a/app/domain/show-domain/src/main/java/org/example/entity/show/Show.java
+++ b/app/domain/show-domain/src/main/java/org/example/entity/show/Show.java
@@ -116,13 +116,16 @@ public class Show extends BaseEntity {
             .build();
     }
 
-    public void changeShowInfo(Show newShow) {
-        this.title = newShow.title;
-        this.content = newShow.content;
-        this.startDate = newShow.startDate;
-        this.location = newShow.location;
-        this.image = newShow.image;
-        this.seatPrices = newShow.seatPrices;
+    public void changeShowInfo(Show updateShow) {
+        this.title = updateShow.title;
+        this.content = updateShow.content;
+        this.startDate = updateShow.startDate;
+        this.endDate = updateShow.endDate;
+        this.location = updateShow.location;
+        this.image = updateShow.image;
+        this.lastTicketingAt = updateShow.lastTicketingAt;
+        this.seatPrices = updateShow.seatPrices;
+        this.ticketingSites = updateShow.ticketingSites;
     }
 
     public void view() {

--- a/app/domain/show-domain/src/main/java/org/example/usecase/artist/ArtistUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/artist/ArtistUseCase.java
@@ -151,7 +151,5 @@ public class ArtistUseCase {
         return artistRepository.findById(id)
             .orElseThrow(NoSuchElementException::new);
     }
-
-
 }
 

--- a/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowAdminUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowAdminUseCase.java
@@ -1,0 +1,196 @@
+package org.example.usecase.show;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.example.dto.show.request.ShowCreationDomainRequest;
+import org.example.dto.show.request.ShowUpdateDomainRequest;
+import org.example.dto.show.response.ShowInfoDomainResponse;
+import org.example.dto.show.response.ShowWithTicketingTimesDomainResponse;
+import org.example.entity.BaseEntity;
+import org.example.entity.show.Show;
+import org.example.entity.show.ShowArtist;
+import org.example.entity.show.ShowGenre;
+import org.example.entity.show.ShowSearch;
+import org.example.entity.show.info.ShowTicketingTimes;
+import org.example.repository.show.ShowRepository;
+import org.example.repository.show.showartist.ShowArtistRepository;
+import org.example.repository.show.showgenre.ShowGenreRepository;
+import org.example.repository.show.showsearch.ShowSearchRepository;
+import org.example.repository.show.showticketing.ShowTicketingTimeRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ShowAdminUseCase {
+
+    private final ShowRepository showRepository;
+    private final ShowSearchRepository showSearchRepository;
+    private final ShowArtistRepository showArtistRepository;
+    private final ShowGenreRepository showGenreRepository;
+    private final ShowTicketingTimeRepository showTicketingTimeRepository;
+
+    @Transactional
+    public void save(
+        ShowCreationDomainRequest request
+    ) {
+        Show show = request.toShow();
+        showRepository.save(show);
+        showSearchRepository.save(show.toShowSearch());
+
+        var showArtists = show.toShowArtist(request.artistIds());
+        showArtistRepository.saveAll(showArtists);
+
+        var showGenres = show.toShowGenre(request.genreIds());
+        showGenreRepository.saveAll(showGenres);
+
+        var showTicketingTimes = show.toShowTicketingTime(
+            request.showTicketingTimes());
+        showTicketingTimeRepository.saveAll(showTicketingTimes);
+    }
+
+    public List<ShowWithTicketingTimesDomainResponse> findShowDetailWithTicketingTimes() {
+        return showRepository.findShowDetailWithTicketingTimes();
+    }
+
+    public ShowInfoDomainResponse findShowInfo(UUID id) {
+        return showRepository.findShowInfoById(id).orElseThrow(NoSuchElementException::new);
+    }
+
+    @Transactional
+    public void updateShow(UUID id, ShowUpdateDomainRequest request) {
+        Show show = findShowOrThrowNoSuchElementException(id);
+        Show updateShow = request.toShow();
+
+        show.changeShowInfo(updateShow);
+        updateShowSearch(show);
+        updateShowArtist(request.artistIds(), show);
+        updateShowGenre(request.genreIds(), show);
+        updateShowTicketingTimes(request.showTicketingTimes(), show);
+    }
+
+    public void updateShowSearch(Show show) {
+        var newShowSearch = show.toShowSearch();
+        var currentShowSearches = findShowSearchesByShowId(show.getId());
+        var showNames = currentShowSearches.stream().map(ShowSearch::getName).toList();
+
+        if (!showNames.contains(newShowSearch.getName())) {
+            showSearchRepository.save(newShowSearch);
+
+            var showSearchesToRemove = currentShowSearches.stream()
+                .filter(showSearch -> !newShowSearch.getName().equals(showSearch.getName()))
+                .toList();
+            showSearchesToRemove.forEach(BaseEntity::softDelete);
+        }
+    }
+
+    public void updateShowArtist(List<UUID> newArtistIds, Show show) {
+        var currentShowArtists = findShowArtistsByShowId(show.getId());
+        var artistIdsToAdd = getArtistIdsToAdd(newArtistIds, currentShowArtists);
+        showArtistRepository.saveAll(show.toShowArtist(artistIdsToAdd));
+
+        var showArtistsToRemove = currentShowArtists.stream()
+            .filter(showArtist -> !newArtistIds.contains(showArtist.getArtistId()))
+            .toList();
+        showArtistsToRemove.forEach(BaseEntity::softDelete);
+    }
+
+    public List<UUID> getArtistIdsToAdd(
+        List<UUID> newArtistIds,
+        List<ShowArtist> currentShowArtists
+    ) {
+        var currentArtistIds = currentShowArtists.stream()
+            .map(ShowArtist::getArtistId)
+            .toList();
+
+        return newArtistIds.stream()
+            .filter(newArtistId -> !currentArtistIds.contains(newArtistId))
+            .toList();
+    }
+
+    public void updateShowGenre(List<UUID> newGenreIds, Show show) {
+        List<ShowGenre> currentShowGenres = findShowGenresByShowId(show.getId());
+        List<UUID> genreIdsToAdd = getGenreIdsToAdd(newGenreIds, currentShowGenres);
+        showGenreRepository.saveAll(show.toShowGenre(genreIdsToAdd));
+
+        List<ShowGenre> showGenresToRemove = currentShowGenres.stream()
+            .filter(showGenre -> !newGenreIds.contains(showGenre.getGenreId()))
+            .toList();
+        showGenresToRemove.forEach(BaseEntity::softDelete);
+    }
+
+    public List<UUID> getGenreIdsToAdd(
+        List<UUID> newGenreIds,
+        List<ShowGenre> currentShowGenres
+    ) {
+        var currentGenreIds = currentShowGenres.stream()
+            .map(ShowGenre::getGenreId)
+            .toList();
+
+        return newGenreIds.stream()
+            .filter(newGenreId -> !currentGenreIds.contains(newGenreId))
+            .toList();
+    }
+
+    public void updateShowTicketingTimes(ShowTicketingTimes ticketingTimes, Show show) {
+        var currentShowTicketingTimes = showTicketingTimeRepository.findAllByShowIdAndIsDeletedFalse(
+            show.getId()
+        );
+
+        var newShowTicketingTimes = show.toShowTicketingTime(ticketingTimes);
+        var ticketingTimesToAdd = newShowTicketingTimes.stream()
+            .filter(
+                newTicketingTime ->
+                    !currentShowTicketingTimes.contains(newTicketingTime)
+            )
+            .toList();
+        showTicketingTimeRepository.saveAll(ticketingTimesToAdd);
+
+        var showGenresToRemove = currentShowTicketingTimes.stream()
+            .filter(curTicketingTime -> !newShowTicketingTimes.contains(curTicketingTime))
+            .toList();
+        showGenresToRemove.forEach(BaseEntity::softDelete);
+    }
+
+    @Transactional
+    public void deleteShow(UUID id) {
+        Show show = findShowOrThrowNoSuchElementException(id);
+        show.softDelete();
+
+        var showArtists = showArtistRepository.findAllByShowIdAndIsDeletedFalse(
+            show.getId());
+        showArtists.forEach(BaseEntity::softDelete);
+
+        var showGenres = showGenreRepository.findAllByShowIdAndIsDeletedFalse(
+            show.getId());
+        showGenres.forEach(BaseEntity::softDelete);
+
+        var showSearches = showSearchRepository.findAllByShowIdAndIsDeletedFalse(
+            show.getId());
+        showSearches.forEach(BaseEntity::softDelete);
+
+        var showTicketingTimes = showTicketingTimeRepository.findAllByShowIdAndIsDeletedFalse(
+            show.getId()
+        );
+        showTicketingTimes.forEach(BaseEntity::softDelete);
+    }
+
+
+    public List<ShowArtist> findShowArtistsByShowId(UUID showId) {
+        return showArtistRepository.findAllByShowIdAndIsDeletedFalse(showId);
+    }
+
+    public List<ShowGenre> findShowGenresByShowId(UUID showId) {
+        return showGenreRepository.findAllByShowIdAndIsDeletedFalse(showId);
+    }
+
+    public List<ShowSearch> findShowSearchesByShowId(UUID showId) {
+        return showSearchRepository.findAllByShowIdAndIsDeletedFalse(showId);
+    }
+
+    private Show findShowOrThrowNoSuchElementException(UUID id) {
+        return showRepository.findById(id).orElseThrow(NoSuchElementException::new);
+    }
+}

--- a/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
@@ -6,26 +6,15 @@ import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.example.dto.show.request.ShowAlertPaginationDomainRequest;
-import org.example.dto.show.request.ShowCreationDomainRequest;
 import org.example.dto.show.request.ShowPaginationDomainRequest;
 import org.example.dto.show.request.ShowSearchPaginationDomainRequest;
-import org.example.dto.show.request.ShowUpdateDomainRequest;
 import org.example.dto.show.response.ShowAlertPaginationDomainResponse;
 import org.example.dto.show.response.ShowDetailDomainResponse;
-import org.example.dto.show.response.ShowInfoDomainResponse;
 import org.example.dto.show.response.ShowPaginationDomainResponse;
 import org.example.dto.show.response.ShowSearchPaginationDomainResponse;
-import org.example.dto.show.response.ShowWithTicketingTimesDomainResponse;
-import org.example.entity.BaseEntity;
 import org.example.entity.show.Show;
-import org.example.entity.show.ShowArtist;
-import org.example.entity.show.ShowGenre;
-import org.example.entity.show.ShowSearch;
 import org.example.entity.show.ShowTicketingTime;
-import org.example.entity.show.info.ShowTicketingTimes;
 import org.example.repository.show.ShowRepository;
-import org.example.repository.show.showartist.ShowArtistRepository;
-import org.example.repository.show.showgenre.ShowGenreRepository;
 import org.example.repository.show.showsearch.ShowSearchRepository;
 import org.example.repository.show.showticketing.ShowTicketingTimeRepository;
 import org.example.vo.TicketingType;
@@ -38,39 +27,10 @@ public class ShowUseCase {
 
     private final ShowRepository showRepository;
     private final ShowSearchRepository showSearchRepository;
-    private final ShowArtistRepository showArtistRepository;
-    private final ShowGenreRepository showGenreRepository;
     private final ShowTicketingTimeRepository showTicketingTimeRepository;
-
-    @Transactional
-    public void save(
-        ShowCreationDomainRequest request
-    ) {
-        Show show = request.toShow();
-        showRepository.save(show);
-        showSearchRepository.save(show.toShowSearch());
-
-        var showArtists = show.toShowArtist(request.artistIds());
-        showArtistRepository.saveAll(showArtists);
-
-        var showGenres = show.toShowGenre(request.genreIds());
-        showGenreRepository.saveAll(showGenres);
-
-        var showTicketingTimes = show.toShowTicketingTime(
-            request.showTicketingTimes());
-        showTicketingTimeRepository.saveAll(showTicketingTimes);
-    }
-
-    public List<ShowWithTicketingTimesDomainResponse> findShowDetailWithTicketingTimes() {
-        return showRepository.findShowDetailWithTicketingTimes();
-    }
 
     public ShowDetailDomainResponse findShowDetail(UUID id) {
         return showRepository.findShowDetailById(id).orElseThrow(NoSuchElementException::new);
-    }
-
-    public ShowInfoDomainResponse findShowInfo(UUID id) {
-        return showRepository.findShowInfoById(id).orElseThrow(NoSuchElementException::new);
     }
 
     public ShowPaginationDomainResponse findShows(ShowPaginationDomainRequest request) {
@@ -81,146 +41,16 @@ public class ShowUseCase {
         return showRepository.findShowsByIdIn(showIds);
     }
 
-    @Transactional
-    public void updateShow(UUID id, ShowUpdateDomainRequest request) {
-        Show show = findShowOrThrowNoSuchElementException(id);
-        Show updateShow = request.toShow();
-
-        show.changeShowInfo(updateShow);
-        updateShowSearch(show);
-        updateShowArtist(request.artistIds(), show);
-        updateShowGenre(request.genreIds(), show);
-        updateShowTicketingTimes(request.showTicketingTimes(), show);
-    }
-
-    public void updateShowSearch(Show show) {
-        var newShowSearch = show.toShowSearch();
-        var currentShowSearches = findShowSearchesByShowId(show.getId());
-        var showNames = currentShowSearches.stream().map(ShowSearch::getName).toList();
-
-        if (!showNames.contains(newShowSearch.getName())) {
-            showSearchRepository.save(newShowSearch);
-
-            var showSearchesToRemove = currentShowSearches.stream()
-                .filter(showSearch -> !newShowSearch.getName().equals(showSearch.getName()))
-                .toList();
-            showSearchesToRemove.forEach(BaseEntity::softDelete);
-        }
-    }
-
-    public void updateShowArtist(List<UUID> newArtistIds, Show show) {
-        var currentShowArtists = findShowArtistsByShowId(show.getId());
-        var artistIdsToAdd = getArtistIdsToAdd(newArtistIds, currentShowArtists);
-        showArtistRepository.saveAll(show.toShowArtist(artistIdsToAdd));
-
-        var showArtistsToRemove = currentShowArtists.stream()
-            .filter(showArtist -> !newArtistIds.contains(showArtist.getArtistId()))
-            .toList();
-        showArtistsToRemove.forEach(BaseEntity::softDelete);
-    }
-
-    public List<UUID> getArtistIdsToAdd(
-        List<UUID> newArtistIds,
-        List<ShowArtist> currentShowArtists
-    ) {
-        var currentArtistIds = currentShowArtists.stream()
-            .map(ShowArtist::getArtistId)
-            .toList();
-
-        return newArtistIds.stream()
-            .filter(newArtistId -> !currentArtistIds.contains(newArtistId))
-            .toList();
-    }
-
-    public void updateShowGenre(List<UUID> newGenreIds, Show show) {
-        List<ShowGenre> currentShowGenres = findShowGenresByShowId(show.getId());
-        List<UUID> genreIdsToAdd = getGenreIdsToAdd(newGenreIds, currentShowGenres);
-        showGenreRepository.saveAll(show.toShowGenre(genreIdsToAdd));
-
-        List<ShowGenre> showGenresToRemove = currentShowGenres.stream()
-            .filter(showGenre -> !newGenreIds.contains(showGenre.getGenreId()))
-            .toList();
-        showGenresToRemove.forEach(BaseEntity::softDelete);
-    }
-
-    public List<UUID> getGenreIdsToAdd(
-        List<UUID> newGenreIds,
-        List<ShowGenre> currentShowGenres
-    ) {
-        var currentGenreIds = currentShowGenres.stream()
-            .map(ShowGenre::getGenreId)
-            .toList();
-
-        return newGenreIds.stream()
-            .filter(newGenreId -> !currentGenreIds.contains(newGenreId))
-            .toList();
-    }
-
-    public void updateShowTicketingTimes(ShowTicketingTimes ticketingTimes, Show show) {
-        var currentShowTicketingTimes = showTicketingTimeRepository.findAllByShowIdAndIsDeletedFalse(
-            show.getId()
-        );
-
-        var newShowTicketingTimes = show.toShowTicketingTime(ticketingTimes);
-        var ticketingTimesToAdd = newShowTicketingTimes.stream()
-            .filter(
-                newTicketingTime ->
-                    !currentShowTicketingTimes.contains(newTicketingTime)
-            )
-            .toList();
-        showTicketingTimeRepository.saveAll(ticketingTimesToAdd);
-
-        var showGenresToRemove = currentShowTicketingTimes.stream()
-            .filter(curTicketingTime -> !newShowTicketingTimes.contains(curTicketingTime))
-            .toList();
-        showGenresToRemove.forEach(BaseEntity::softDelete);
-    }
-
     // TODO: 동시성 이슈 고려 안 함
     @Transactional
     public void view(UUID id) {
         findShowOrThrowNoSuchElementException(id).view();
     }
 
-    @Transactional
-    public void deleteShow(UUID id) {
-        Show show = findShowOrThrowNoSuchElementException(id);
-        show.softDelete();
-
-        var showArtists = showArtistRepository.findAllByShowIdAndIsDeletedFalse(
-            show.getId());
-        showArtists.forEach(BaseEntity::softDelete);
-
-        var showGenres = showGenreRepository.findAllByShowIdAndIsDeletedFalse(
-            show.getId());
-        showGenres.forEach(BaseEntity::softDelete);
-
-        var showSearches = showSearchRepository.findAllByShowIdAndIsDeletedFalse(
-            show.getId());
-        showSearches.forEach(BaseEntity::softDelete);
-
-        var showTicketingTimes = showTicketingTimeRepository.findAllByShowIdAndIsDeletedFalse(
-            show.getId()
-        );
-        showTicketingTimes.forEach(BaseEntity::softDelete);
-    }
-
     public ShowSearchPaginationDomainResponse searchShow(
         ShowSearchPaginationDomainRequest request
     ) {
         return showSearchRepository.searchShow(request);
-    }
-
-    public List<ShowArtist> findShowArtistsByShowId(UUID showId) {
-        return showArtistRepository.findAllByShowIdAndIsDeletedFalse(showId);
-    }
-
-    public List<ShowGenre> findShowGenresByShowId(UUID showId) {
-        return showGenreRepository.findAllByShowIdAndIsDeletedFalse(showId);
-    }
-
-    public List<ShowSearch> findShowSearchesByShowId(UUID showId) {
-        return showSearchRepository.findAllByShowIdAndIsDeletedFalse(showId);
     }
 
     public ShowAlertPaginationDomainResponse findAlertShows(

--- a/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
@@ -84,7 +84,9 @@ public class ShowUseCase {
     @Transactional
     public void updateShow(UUID id, ShowUpdateDomainRequest request) {
         Show show = findShowOrThrowNoSuchElementException(id);
+        Show updateShow = request.toShow();
 
+        show.changeShowInfo(updateShow);
         updateShowSearch(show);
         updateShowArtist(request.artistIds(), show);
         updateShowGenre(request.genreIds(), show);
@@ -94,12 +96,13 @@ public class ShowUseCase {
     public void updateShowSearch(Show show) {
         var newShowSearch = show.toShowSearch();
         var currentShowSearches = findShowSearchesByShowId(show.getId());
+        var showNames = currentShowSearches.stream().map(ShowSearch::getName).toList();
 
-        if (!currentShowSearches.contains(newShowSearch)) {
+        if (!showNames.contains(newShowSearch.getName())) {
             showSearchRepository.save(newShowSearch);
 
             var showSearchesToRemove = currentShowSearches.stream()
-                .filter(currentShowSearch -> !newShowSearch.equals(currentShowSearch))
+                .filter(showSearch -> !newShowSearch.getName().equals(showSearch.getName()))
                 .toList();
             showSearchesToRemove.forEach(BaseEntity::softDelete);
         }

--- a/common/src/main/java/org/example/exception/GlobalError.java
+++ b/common/src/main/java/org/example/exception/GlobalError.java
@@ -88,5 +88,27 @@ public enum GlobalError implements BusinessError {
         public String getLogMessage() {
             return "파라마티 타입이 일치하지 않습니다.";
         }
+    },
+
+    ELEMENT_NOT_FOUND {
+        @Override
+        public int getHttpStatus() {
+            return 404;
+        }
+
+        @Override
+        public String getErrorCode() {
+            return "GLOBAL-005";
+        }
+
+        @Override
+        public String getClientMessage() {
+            return "요청에 일치하는 데이터를 찾지 못했습니다.";
+        }
+
+        @Override
+        public String getLogMessage() {
+            return "요청에 일치하는 데이터를 찾지 못했습니다.";
+        }
     }
 }


### PR DESCRIPTION
## 😋 작업한 내용

- 공연 데이터 업데이트 시 업데이트 된 데이터로 저장이 안되는 오류를 해결 하였습니다. (기존에는 이전 데이터를 계속 유지합니다.)


## 🙏 PR Point

- showUseCase가 점점 커져서 showAdminUseCase를 빼서 관리하였습니다.
- NoSuchElementException을 하나하나 try catch가 안되어 있는 경우가 많고, try catch로 잡을 경우 핵심 서비스 로직이 보이지 않는 문제가 있어서 Global에서 뺐는데, 어떤지 생각을 듣고 싶습니당. 특정 경우에만 try catch를 잡아서 상황에 맞게 전달하면 될 것 같아서용

## 👍 관련 이슈

- Resolved : #115 


---