### PR TITLE
fix: 구독 알림 메시지 Publish 필드 누락

### DIFF
--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistSearchPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistSearchPaginationApiParam.java
@@ -18,7 +18,7 @@ public record ArtistSearchPaginationApiParam(
     String englishName,
 
     @Schema(description = "아티스트 구독 여부")
-    boolean isSubscribe
+    boolean isSubscribed
 ) {
 
     public static ArtistSearchPaginationApiParam from(ArtistSearchPaginationServiceParam param) {
@@ -27,7 +27,7 @@ public record ArtistSearchPaginationApiParam(
             param.artistImageUrl(),
             param.artistKoreanName(),
             param.artistEnglishName(),
-            param.isSubscribe()
+            param.isSubscribed()
         );
     }
 }

--- a/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/ArtistService.java
@@ -13,6 +13,7 @@ import com.example.artist.service.dto.response.ArtistFilterTotalCountServiceResp
 import com.example.artist.service.dto.response.ArtistSubscriptionServiceResponse;
 import com.example.artist.service.dto.response.ArtistUnsubscriptionServiceResponse;
 import com.example.publish.MessagePublisher;
+import com.example.publish.message.ArtistServiceMessage;
 import com.example.publish.message.ArtistSubscriptionServiceMessage;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -90,13 +91,16 @@ public class ArtistService {
             .map(ArtistSubscription::getArtistId)
             .toList();
 
+        var subscribedArtistMessage = artistUseCase.findAllArtistInIds(subscribedArtistIds)
+            .stream().map(ArtistServiceMessage::from)
+            .toList();
         var userFcmToken = userUseCase.findUserFcmTokensByUserId(request.userId());
 
         messagePublisher.publishArtistSubscription(
             "artistSubscription",
             ArtistSubscriptionServiceMessage.from(
                 userFcmToken,
-                subscribedArtistIds
+                subscribedArtistMessage
             )
         );
 
@@ -115,16 +119,18 @@ public class ArtistService {
             request.artistIds(),
             request.userId()
         );
-        var unsubscribedArtistIds = unsubscribedArtists.stream()
-            .map(ArtistSubscription::getArtistId)
+        var unsubscribedArtistMessage = unsubscribedArtists.stream()
+            .map(ArtistServiceMessage::toUnsubscribe)
             .toList();
 
+
         var userFcmToken = userUseCase.findUserFcmTokensByUserId(request.userId());
+
         messagePublisher.publishArtistSubscription(
             "artistUnsubscription",
             ArtistSubscriptionServiceMessage.from(
                 userFcmToken,
-                unsubscribedArtistIds
+                unsubscribedArtistMessage
             )
         );
 

--- a/app/api/show-api/src/main/java/com/example/artist/service/dto/param/ArtistSearchPaginationServiceParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/service/dto/param/ArtistSearchPaginationServiceParam.java
@@ -11,21 +11,21 @@ public record ArtistSearchPaginationServiceParam(
     String artistImageUrl,
     String artistKoreanName,
     String artistEnglishName,
-    boolean isSubscribe
+    boolean isSubscribed
 ) {
 
     public static ArtistSearchPaginationServiceParam from(
         ArtistSimpleDomainResponse response,
         List<UUID> artistSubscriptions
     ) {
-        boolean isSubscribe = artistSubscriptions.contains(response.id());
+        boolean isSubscribed = artistSubscriptions.contains(response.id());
 
         return ArtistSearchPaginationServiceParam.builder()
             .artistId(response.id())
             .artistImageUrl(response.image())
             .artistKoreanName(response.koreanName())
             .artistEnglishName(response.englishName())
-            .isSubscribe(isSubscribe)
+            .isSubscribed(isSubscribed)
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/genre/service/GenreService.java
+++ b/app/api/show-api/src/main/java/com/example/genre/service/GenreService.java
@@ -9,6 +9,7 @@ import com.example.genre.service.dto.request.GenreUnsubscriptionServiceRequest;
 import com.example.genre.service.dto.response.GenreSubscriptionServiceResponse;
 import com.example.genre.service.dto.response.GenreUnsubscriptionServiceResponse;
 import com.example.publish.MessagePublisher;
+import com.example.publish.message.GenreServiceMessage;
 import com.example.publish.message.GenreSubscriptionServiceMessage;
 import java.util.List;
 import java.util.UUID;
@@ -45,13 +46,16 @@ public class GenreService {
             .map(GenreSubscription::getGenreId)
             .toList();
 
+        var subscribedGenreMessage = genreUseCase.findAllGenresInIds(subscribedGenreIds)
+            .stream().map(GenreServiceMessage::from)
+            .toList();
         var userFcmToken = userUseCase.findUserFcmTokensByUserId(request.userId());
 
         messagePublisher.publishGenreSubscription(
             "genreSubscription",
             GenreSubscriptionServiceMessage.from(
                 userFcmToken,
-                subscribedGenreIds
+                subscribedGenreMessage
             )
         );
 
@@ -71,9 +75,8 @@ public class GenreService {
             request.genreIds(),
             request.userId()
         );
-        var unsubscribedGenreIds = unsubscriptionGenres
-            .stream()
-            .map(GenreSubscription::getGenreId)
+        var unsubscribedGenreMessage = unsubscriptionGenres.stream()
+            .map(GenreServiceMessage::toUnsubscribe)
             .toList();
 
         var userFcmToken = userUseCase.findUserFcmTokensByUserId(request.userId());
@@ -82,7 +85,7 @@ public class GenreService {
             "genreUnsubscription",
             GenreSubscriptionServiceMessage.from(
                 userFcmToken,
-                unsubscribedGenreIds
+                unsubscribedGenreMessage
             )
         );
 

--- a/app/api/show-api/src/main/java/com/example/publish/message/ArtistServiceMessage.java
+++ b/app/api/show-api/src/main/java/com/example/publish/message/ArtistServiceMessage.java
@@ -1,0 +1,27 @@
+package com.example.publish.message;
+
+import java.util.UUID;
+import lombok.Builder;
+import org.example.entity.ArtistSubscription;
+import org.example.entity.artist.Artist;
+
+@Builder
+public record ArtistServiceMessage(
+    UUID id,
+    String name
+) {
+
+    public static ArtistServiceMessage from(Artist artist) {
+        return ArtistServiceMessage.builder()
+            .id(artist.getId())
+            .name(artist.getEnglishName())
+            .build();
+    }
+
+    public static ArtistServiceMessage toUnsubscribe(ArtistSubscription artistSubscription) {
+        return ArtistServiceMessage.builder()
+            .id(artistSubscription.getArtistId())
+            .name("empty")
+            .build();
+    }
+}

--- a/app/api/show-api/src/main/java/com/example/publish/message/ArtistSubscriptionServiceMessage.java
+++ b/app/api/show-api/src/main/java/com/example/publish/message/ArtistSubscriptionServiceMessage.java
@@ -1,22 +1,21 @@
 package com.example.publish.message;
 
 import java.util.List;
-import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record ArtistSubscriptionServiceMessage(
     String userFcmToken,
-    List<UUID> artistIds
+    List<ArtistServiceMessage> artists
 ) {
 
     public static ArtistSubscriptionServiceMessage from(
         String userFcmToken,
-        List<UUID> artistIds
+        List<ArtistServiceMessage> artists
     ) {
         return ArtistSubscriptionServiceMessage.builder()
             .userFcmToken(userFcmToken)
-            .artistIds(artistIds)
+            .artists(artists)
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/publish/message/GenreServiceMessage.java
+++ b/app/api/show-api/src/main/java/com/example/publish/message/GenreServiceMessage.java
@@ -1,0 +1,27 @@
+package com.example.publish.message;
+
+import java.util.UUID;
+import lombok.Builder;
+import org.example.entity.GenreSubscription;
+import org.example.entity.genre.Genre;
+
+@Builder
+public record GenreServiceMessage(
+    UUID id,
+    String name
+) {
+
+    public static GenreServiceMessage from(Genre genre) {
+        return GenreServiceMessage.builder()
+            .id(genre.getId())
+            .name(genre.getName())
+            .build();
+    }
+
+    public static GenreServiceMessage toUnsubscribe(GenreSubscription genreSubscription) {
+        return GenreServiceMessage.builder()
+            .id(genreSubscription.getGenreId())
+            .name("empty")
+            .build();
+    }
+}

--- a/app/api/show-api/src/main/java/com/example/publish/message/GenreSubscriptionServiceMessage.java
+++ b/app/api/show-api/src/main/java/com/example/publish/message/GenreSubscriptionServiceMessage.java
@@ -1,22 +1,21 @@
 package com.example.publish.message;
 
 import java.util.List;
-import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record GenreSubscriptionServiceMessage(
     String userFcmToken,
-    List<UUID> genreIds
+    List<GenreServiceMessage> genres
 ) {
 
     public static GenreSubscriptionServiceMessage from(
         String userFcmToken,
-        List<UUID> genreIds
+        List<GenreServiceMessage> genres
     ) {
         return GenreSubscriptionServiceMessage.builder()
             .userFcmToken(userFcmToken)
-            .genreIds(genreIds)
+            .genres(genres)
             .build();
     }
 }

--- a/app/domain/common-domain/src/main/resources/schema.sql
+++ b/app/domain/common-domain/src/main/resources/schema.sql
@@ -249,6 +249,7 @@ create table alarm.artist_subscription
     created_at     timestamp(3) not null,
     updated_at     timestamp(3) not null,
     artist_id      uuid         not null,
+    artist_name    varchar(255) not null,
     id             uuid         not null,
     user_fcm_token varchar(255) not null,
     primary key (id)
@@ -260,6 +261,7 @@ create table alarm.genre_subscription
     created_at     timestamp(3) not null,
     updated_at     timestamp(3) not null,
     genre_id       uuid         not null,
+    genre_name     varchar(255) not null,
     id             uuid         not null,
     user_fcm_token varchar(255) not null,
     primary key (id)

--- a/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowAdminUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowAdminUseCase.java
@@ -46,8 +46,7 @@ public class ShowAdminUseCase {
         var showGenres = show.toShowGenre(request.genreIds());
         showGenreRepository.saveAll(showGenres);
 
-        var showTicketingTimes = show.toShowTicketingTime(
-            request.showTicketingTimes());
+        var showTicketingTimes = show.toShowTicketingTime(request.showTicketingTimes());
         showTicketingTimeRepository.saveAll(showTicketingTimes);
     }
 

--- a/app/infrastructure/message-queue/src/main/java/org/example/message/ArtistInfraMessage.java
+++ b/app/infrastructure/message-queue/src/main/java/org/example/message/ArtistInfraMessage.java
@@ -1,0 +1,19 @@
+package org.example.message;
+
+import com.example.publish.message.ArtistServiceMessage;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record ArtistInfraMessage(
+    UUID artistId,
+    String artistName
+) {
+
+    public static ArtistInfraMessage from(ArtistServiceMessage message) {
+        return ArtistInfraMessage.builder()
+            .artistId(message.id())
+            .artistName(message.name())
+            .build();
+    }
+}

--- a/app/infrastructure/message-queue/src/main/java/org/example/message/ArtistSubscriptionInfraMessage.java
+++ b/app/infrastructure/message-queue/src/main/java/org/example/message/ArtistSubscriptionInfraMessage.java
@@ -2,13 +2,12 @@ package org.example.message;
 
 import com.example.publish.message.ArtistSubscriptionServiceMessage;
 import java.util.List;
-import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record ArtistSubscriptionInfraMessage(
     String userFcmToken,
-    List<UUID> artistIds
+    List<ArtistInfraMessage> artists
 ) {
 
     public static ArtistSubscriptionInfraMessage from(
@@ -16,7 +15,7 @@ public record ArtistSubscriptionInfraMessage(
     ) {
         return ArtistSubscriptionInfraMessage.builder()
             .userFcmToken(message.userFcmToken())
-            .artistIds(message.artistIds())
+            .artists(message.artists().stream().map(ArtistInfraMessage::from).toList())
             .build();
     }
 }

--- a/app/infrastructure/message-queue/src/main/java/org/example/message/GenreInfraMessage.java
+++ b/app/infrastructure/message-queue/src/main/java/org/example/message/GenreInfraMessage.java
@@ -1,0 +1,19 @@
+package org.example.message;
+
+import com.example.publish.message.GenreServiceMessage;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record GenreInfraMessage(
+    UUID genreId,
+    String genreName
+) {
+
+    public static GenreInfraMessage from(GenreServiceMessage message) {
+        return GenreInfraMessage.builder()
+            .genreId(message.id())
+            .genreName(message.name())
+            .build();
+    }
+}

--- a/app/infrastructure/message-queue/src/main/java/org/example/message/GenreSubscriptionInfraMessage.java
+++ b/app/infrastructure/message-queue/src/main/java/org/example/message/GenreSubscriptionInfraMessage.java
@@ -2,13 +2,12 @@ package org.example.message;
 
 import com.example.publish.message.GenreSubscriptionServiceMessage;
 import java.util.List;
-import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record GenreSubscriptionInfraMessage(
     String userFcmToken,
-    List<UUID> genreIds
+    List<GenreInfraMessage> genres
 ) {
 
     public static GenreSubscriptionInfraMessage from(
@@ -16,7 +15,7 @@ public record GenreSubscriptionInfraMessage(
     ) {
         return GenreSubscriptionInfraMessage.builder()
             .userFcmToken(message.userFcmToken())
-            .genreIds(message.genreIds())
+            .genres(message.genres().stream().map(GenreInfraMessage::from).toList())
             .build();
     }
 }


### PR DESCRIPTION
## 😋 작업한 내용

- 구독 알림 메시지시 FCM으로 전송할 아티스트 이름, 장르 이름 필드를 publish할때 추가해 주었습니다. 
- 아티스트 이름은 영어 이름으로 전송했습니다. 
- 추가적으로 아티스트 검색 시 isSubscribed pp 형으로 변경했습니다. 

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #125 


---