### PR TITLE
feat: 장르 전체 목록 조회 기능 구현

### DIFF
--- a/app/api/show-api/src/main/java/com/example/genre/controller/GenreController.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/GenreController.java
@@ -1,7 +1,9 @@
 package com.example.genre.controller;
 
+import com.example.genre.controller.dto.param.GenrePaginationApiParam;
 import com.example.genre.controller.dto.param.GenreSubscriptionPaginationApiParam;
 import com.example.genre.controller.dto.param.GenreUnsubscriptionPaginationApiParam;
+import com.example.genre.controller.dto.request.GenrePaginationApiRequest;
 import com.example.genre.controller.dto.request.GenreSubscriptionApiRequest;
 import com.example.genre.controller.dto.request.GenreSubscriptionPaginationApiRequest;
 import com.example.genre.controller.dto.request.GenreUnsubscriptionApiRequest;
@@ -32,13 +34,33 @@ public class GenreController {
 
     private final GenreService genreService;
 
+    @GetMapping
+    @Operation(summary = "장르 전체 목록 조회")
+    public ResponseEntity<PaginationApiResponse<GenrePaginationApiParam>> getGenres(
+        @AuthenticationPrincipal AuthenticatedUser user,
+        @ParameterObject GenrePaginationApiRequest request
+    ) {
+        var response = genreService.findGenres(request.toServiceRequest(user));
+        var data = response.data().stream()
+            .map(GenrePaginationApiParam::new)
+            .toList();
+
+        return ResponseEntity.ok(
+            PaginationApiResponse.<GenrePaginationApiParam>builder()
+                .hasNext(response.hasNext())
+                .data(data)
+                .build()
+        );
+    }
+
     @GetMapping("/unsubscriptions")
     @Operation(summary = "구독하지 않은 장르 목록 조회")
     public ResponseEntity<PaginationApiResponse<GenreUnsubscriptionPaginationApiParam>> getUnsubscribedGenres(
         @AuthenticationPrincipal AuthenticatedUser user,
         @ParameterObject GenreUnsubscriptionPaginationApiRequest request
     ) {
-        var response = genreService.findGenreUnSubscriptions(request.toServiceRequest(user.userId()));
+        var response = genreService.findGenreUnSubscriptions(
+            request.toServiceRequest(user.userId()));
         var data = response.data().stream()
             .map(GenreUnsubscriptionPaginationApiParam::new)
             .toList();

--- a/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenrePaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenrePaginationApiParam.java
@@ -1,0 +1,26 @@
+package com.example.genre.controller.dto.param;
+
+import com.example.genre.service.dto.param.GenrePaginationServiceParam;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+public record GenrePaginationApiParam(
+
+    @Schema(description = "장르 ID")
+    UUID id,
+
+    @Schema(description = "장르 이름")
+    String name,
+
+    @Schema(description = "장르 구독 여부")
+    boolean isSubscribed
+) {
+
+    public GenrePaginationApiParam(GenrePaginationServiceParam param) {
+        this(
+            param.id(),
+            param.name(),
+            param.isSubscribed()
+        );
+    }
+}

--- a/app/api/show-api/src/main/java/com/example/genre/controller/dto/request/GenrePaginationApiRequest.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/dto/request/GenrePaginationApiRequest.java
@@ -1,18 +1,27 @@
 package com.example.genre.controller.dto.request;
 
+import com.example.genre.service.dto.request.GenrePaginationServiceRequest;
+import com.example.vo.SubscriptionStatusApiType;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.util.UUID;
-import org.example.pagination.vo.SortDirection;
-import org.springdoc.core.annotations.ParameterObject;
+import org.example.security.dto.AuthenticatedUser;
 
-@ParameterObject
 public record GenrePaginationApiRequest(
-
-    @Parameter(description = "정렬 방향")
-    SortDirection sortDirection,
-
     @Parameter(description = "이전 페이지네이션 마지막 데이터의 ID / 최초 조회라면 null")
-    UUID cursor
+    UUID cursor,
+
+    @Parameter(description = "조회하는 데이터 개수", required = true)
+    int size
 ) {
 
+    public GenrePaginationServiceRequest toServiceRequest(AuthenticatedUser user) {
+        UUID userId = user == null ? null : user.userId();
+
+        return GenrePaginationServiceRequest.builder()
+            .type(SubscriptionStatusApiType.DEFAULTED)
+            .cursor(cursor)
+            .size(size)
+            .userId(userId)
+            .build();
+    }
 }

--- a/app/api/show-api/src/main/java/com/example/genre/service/GenreService.java
+++ b/app/api/show-api/src/main/java/com/example/genre/service/GenreService.java
@@ -1,7 +1,9 @@
 package com.example.genre.service;
 
+import com.example.genre.service.dto.param.GenrePaginationServiceParam;
 import com.example.genre.service.dto.param.GenreSubscriptionPaginationServiceParam;
 import com.example.genre.service.dto.param.GenreUnsubscriptionPaginationServiceParam;
+import com.example.genre.service.dto.request.GenrePaginationServiceRequest;
 import com.example.genre.service.dto.request.GenreSubscriptionPaginationServiceRequest;
 import com.example.genre.service.dto.request.GenreSubscriptionServiceRequest;
 import com.example.genre.service.dto.request.GenreUnsubscriptionPaginationServiceRequest;
@@ -96,6 +98,21 @@ public class GenreService {
                     .toList()
             )
             .build();
+    }
+
+    public PaginationServiceResponse<GenrePaginationServiceParam> findGenres(GenrePaginationServiceRequest request) {
+        List<UUID> subscriptionGenreIds = request.userId() == null
+            ? List.of()
+            : getSubscriptionGenreIds(request.userId());
+
+        GenrePaginationDomainResponse response = genreUseCase.findGenreWithCursorPagination(
+            request.toDomainRequest());
+
+        List<GenrePaginationServiceParam> data = response.data().stream()
+            .map(genre -> GenrePaginationServiceParam.of(genre, subscriptionGenreIds))
+            .toList();
+
+        return PaginationServiceResponse.of(data, response.hasNext());
     }
 
     public PaginationServiceResponse<GenreSubscriptionPaginationServiceParam> findGenreSubscriptions(

--- a/app/api/show-api/src/main/java/com/example/genre/service/dto/param/GenrePaginationServiceParam.java
+++ b/app/api/show-api/src/main/java/com/example/genre/service/dto/param/GenrePaginationServiceParam.java
@@ -1,0 +1,27 @@
+package com.example.genre.service.dto.param;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.example.dto.genre.response.GenreDomainResponse;
+
+@Builder
+public record GenrePaginationServiceParam(
+    UUID id,
+    String name,
+    boolean isSubscribed
+) {
+
+    public static GenrePaginationServiceParam of(
+        GenreDomainResponse genre,
+        List<UUID> subscriptionGenreIds
+    ) {
+        boolean isSubscribed = subscriptionGenreIds.contains(genre.id());
+
+        return GenrePaginationServiceParam.builder()
+            .id(genre.id())
+            .name(genre.name())
+            .isSubscribed(isSubscribed)
+            .build();
+    }
+}

--- a/app/api/show-api/src/main/java/com/example/genre/service/dto/request/GenrePaginationServiceRequest.java
+++ b/app/api/show-api/src/main/java/com/example/genre/service/dto/request/GenrePaginationServiceRequest.java
@@ -1,0 +1,25 @@
+package com.example.genre.service.dto.request;
+
+import com.example.vo.SubscriptionStatusApiType;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.example.dto.genre.request.GenrePaginationDomainRequest;
+
+@Builder
+public record GenrePaginationServiceRequest(
+    SubscriptionStatusApiType type,
+    UUID cursor,
+    int size,
+    UUID userId
+) {
+    public GenrePaginationDomainRequest toDomainRequest() {
+        return GenrePaginationDomainRequest.builder()
+            .subscriptionStatus(type.toDomainType())
+            .cursor(cursor)
+            .size(size)
+            .genreIds(List.of())
+            .build();
+    }
+
+}

--- a/app/api/show-api/src/main/java/com/example/vo/SubscriptionStatusApiType.java
+++ b/app/api/show-api/src/main/java/com/example/vo/SubscriptionStatusApiType.java
@@ -4,12 +4,14 @@ import org.example.vo.SubscriptionStatus;
 
 public enum SubscriptionStatusApiType {
     SUBSCRIBED,
-    UNSUBSCRIBED;
+    UNSUBSCRIBED,
+    DEFAULTED;
 
     public SubscriptionStatus toDomainType() {
         return switch (this) {
             case SUBSCRIBED -> SubscriptionStatus.SUBSCRIBED;
             case UNSUBSCRIBED -> SubscriptionStatus.UNSUBSCRIBED;
+            case DEFAULTED -> SubscriptionStatus.DEFAULTED;
         };
     }
 }

--- a/app/domain/show-domain/src/main/java/org/example/repository/genre/GenreQuerydslRepositoryImpl.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/genre/GenreQuerydslRepositoryImpl.java
@@ -74,10 +74,15 @@ public class GenreQuerydslRepositoryImpl implements GenreQuerydslRepository {
         BooleanBuilder whereClause = new BooleanBuilder();
         whereClause.and(getDefaultPredicateInCursorPagination(cursor));
 
-        if (status.equals(SubscriptionStatus.SUBSCRIBED)) {
-            return whereClause.and(genre.id.in(genreIds));
+        switch (status) {
+            case SUBSCRIBED -> whereClause.and(genre.id.in(genreIds));
+            case UNSUBSCRIBED -> whereClause.and(genre.id.notIn(genreIds));
+            default -> {
+                return whereClause;
+            }
         }
-        return whereClause.and(genre.id.notIn(genreIds));
+
+        return whereClause;
     }
 
     private Predicate getDefaultPredicateInCursorPagination(UUID cursor) {

--- a/app/domain/show-domain/src/main/java/org/example/vo/SubscriptionStatus.java
+++ b/app/domain/show-domain/src/main/java/org/example/vo/SubscriptionStatus.java
@@ -2,5 +2,6 @@ package org.example.vo;
 
 public enum SubscriptionStatus {
     SUBSCRIBED,
-    UNSUBSCRIBED
+    UNSUBSCRIBED,
+    DEFAULTED
 }


### PR DESCRIPTION
## 😋 작업한 내용

- 장르 전체 목록 조회 기능 구현
- 비회원, 회원 모두 조회 가능
- 응답 필드에 구독 여부 있음
- 쿼리는 동적으로 생성

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #131 


---