### PR TITLE
fix: 공연 전체 목록 조회 기능 수정

### DIFF
--- a/app/api/show-api/src/main/java/com/example/show/controller/ShowController.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/ShowController.java
@@ -21,7 +21,6 @@ import com.example.show.service.dto.response.ShowPaginationServiceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -53,10 +52,8 @@ public class ShowController {
     public ResponseEntity<PaginationApiResponse<ShowPaginationApiParam>> getShows(
         @ParameterObject ShowPaginationApiRequest request
     ) {
-        LocalDateTime now = LocalDateTime.now();
-
         PaginationServiceResponse<ShowPaginationServiceResponse> response = showService.findShows(
-            request.toServiceRequest(now)
+            request.toServiceRequest()
         );
 
         var data = response.data().stream()

--- a/app/api/show-api/src/main/java/com/example/show/controller/dto/request/ShowPaginationApiRequest.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/dto/request/ShowPaginationApiRequest.java
@@ -3,7 +3,6 @@ package com.example.show.controller.dto.request;
 import com.example.show.controller.vo.ShowSortApiType;
 import com.example.show.service.dto.request.ShowPaginationServiceRequest;
 import io.swagger.v3.oas.annotations.Parameter;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springdoc.core.annotations.ParameterObject;
 
@@ -19,20 +18,16 @@ public record ShowPaginationApiRequest(
     @Parameter(description = "이전 페이지네이션 마지막 데이터의 ID / 최초 조회라면 null")
     UUID cursorId,
 
-    @Parameter(description = "이전 페이지네이션 마지막 데이터의 정렬 필드 값 (RECENT: reservationAt, POPULAR: viewCount) / 최초 조회라면 null")
-    UUID cursorValue,
-
     @Parameter(required = true, description = "조회하려는 데이터 개수")
     int size
 ) {
 
-    public ShowPaginationServiceRequest toServiceRequest(LocalDateTime now) {
+    public ShowPaginationServiceRequest toServiceRequest() {
         return ShowPaginationServiceRequest.builder()
             .sort(sort)
+            .onlyOpenSchedule(onlyOpenSchedule)
             .cursorId(cursorId)
-            .cursorValue(cursorValue)
             .size(size)
-            .now(now)
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/controller/dto/response/ShowPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/dto/response/ShowPaginationApiParam.java
@@ -24,8 +24,8 @@ public record ShowPaginationApiParam(
     @Schema(description = "가장 근접한 예매 시간")
     String ticketingAt,
 
-    @Schema(description = "오픈예정 여부")
-    boolean onlyOpenSchedule
+    @Schema(description = "오픈 여부")
+    boolean isOpen
 ) {
 
     public static ShowPaginationApiParam from(ShowPaginationServiceResponse response) {
@@ -35,7 +35,7 @@ public record ShowPaginationApiParam(
             .location(response.location())
             .posterImageURL(response.image())
             .ticketingAt(DateTimeUtil.formatDateTime(response.ticketingAt()))
-            .onlyOpenSchedule(response.onlyOpenSchedule())
+            .isOpen(response.isOpen())
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/controller/dto/response/ShowPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/dto/response/ShowPaginationApiParam.java
@@ -2,9 +2,9 @@ package com.example.show.controller.dto.response;
 
 import com.example.show.service.dto.response.ShowPaginationServiceResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
+import org.example.util.DateTimeUtil;
 
 @Builder
 public record ShowPaginationApiParam(
@@ -22,22 +22,10 @@ public record ShowPaginationApiParam(
     String posterImageURL,
 
     @Schema(description = "가장 근접한 예매 시간")
-    String reservationAt,
+    String ticketingAt,
 
-    @Schema(description = "오픈 예정인 티켓팅 일정이 있는지 여부")
-    boolean hasTicketingOpenSchedule,
-
-    @Schema(description = "조회수")
-    int viewCount,
-
-    @Schema(description = "아티스트 정보")
-    List<ShowArtistPaginationApiParam> artists,
-
-    @Schema(description = "장르 정보")
-    List<ShowGenrePaginationApiParam> genres,
-
-    @Schema(description = "예약 시간 정보")
-    List<ShowTicketingTimePaginationApiParam> showTicketingTimes
+    @Schema(description = "오픈예정 여부")
+    boolean onlyOpenSchedule
 ) {
 
     public static ShowPaginationApiParam from(ShowPaginationServiceResponse response) {
@@ -45,25 +33,9 @@ public record ShowPaginationApiParam(
             .id(response.id())
             .title(response.title())
             .location(response.location())
-            .posterImageURL(response.posterImageURL())
-            .reservationAt(response.reservationAt())
-            .hasTicketingOpenSchedule(response.hasTicketingOpenSchedule())
-            .viewCount(response.viewCount())
-            .artists(
-                response.artists().stream()
-                    .map(ShowArtistPaginationApiParam::from)
-                    .toList()
-            )
-            .genres(
-                response.genres().stream()
-                    .map(ShowGenrePaginationApiParam::from)
-                    .toList()
-            )
-            .showTicketingTimes(
-                response.showTicketingTimes().stream()
-                    .map(ShowTicketingTimePaginationApiParam::from)
-                    .toList()
-            )
+            .posterImageURL(response.image())
+            .ticketingAt(DateTimeUtil.formatDateTime(response.ticketingAt()))
+            .onlyOpenSchedule(response.onlyOpenSchedule())
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
@@ -23,6 +23,7 @@ import com.example.show.service.dto.response.TicketingAlertReservationStatusServ
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -75,9 +76,12 @@ public class ShowService {
         ShowPaginationServiceRequest request
     ) {
         var response = showUseCase.findShows(request.toDomainRequest());
+
         var data = response.data().stream()
-            .map(
-                domainResponse -> ShowPaginationServiceResponse.from(domainResponse, request.now()))
+            .map(domainResponse ->
+                ShowPaginationServiceResponse.of(domainResponse, request.onlyOpenSchedule())
+            )
+            .filter(Objects::nonNull)
             .toList();
 
         return PaginationServiceResponse.of(

--- a/app/api/show-api/src/main/java/com/example/show/service/dto/request/ShowPaginationServiceRequest.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/dto/request/ShowPaginationServiceRequest.java
@@ -1,7 +1,6 @@
 package com.example.show.service.dto.request;
 
 import com.example.show.controller.vo.ShowSortApiType;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
 import org.example.dto.show.request.ShowPaginationDomainRequest;
@@ -11,9 +10,7 @@ public record ShowPaginationServiceRequest(
     ShowSortApiType sort,
     boolean onlyOpenSchedule,
     UUID cursorId,
-    Object cursorValue,
-    int size,
-    LocalDateTime now
+    int size
 ) {
 
     public ShowPaginationDomainRequest toDomainRequest() {
@@ -21,9 +18,7 @@ public record ShowPaginationServiceRequest(
             .sort(sort.toDomainType())
             .onlyOpenSchedule(onlyOpenSchedule)
             .cursorId(cursorId)
-            .cursorValue(cursorValue)
             .size(size)
-            .now(now)
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/service/dto/response/ShowPaginationServiceResponse.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/dto/response/ShowPaginationServiceResponse.java
@@ -12,7 +12,7 @@ public record ShowPaginationServiceResponse(
     LocalDateTime ticketingAt,
     String location,
     String image,
-    boolean onlyOpenSchedule
+    boolean isOpen
 ) {
     public static ShowPaginationServiceResponse of(
         ShowTicketingDomainResponse response,
@@ -30,7 +30,7 @@ public record ShowPaginationServiceResponse(
             .ticketingAt(response.ticketingAt())
             .location(response.location())
             .image(response.image())
-            .onlyOpenSchedule(response.ticketingAt().isAfter(now))
+            .isOpen(response.ticketingAt().isBefore(now))
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/service/dto/response/ShowPaginationServiceResponse.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/dto/response/ShowPaginationServiceResponse.java
@@ -1,59 +1,36 @@
 package com.example.show.service.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.Builder;
-import org.example.dto.show.response.ShowDetailDomainResponse;
-import org.example.util.DateTimeUtil;
+import org.example.dto.show.response.ShowTicketingDomainResponse;
 
 @Builder
 public record ShowPaginationServiceResponse(
     UUID id,
     String title,
+    LocalDateTime ticketingAt,
     String location,
-    String posterImageURL,
-    String reservationAt,
-    boolean hasTicketingOpenSchedule,
-    int viewCount,
-    List<ShowArtistSimpleServiceResponse> artists,
-    List<ShowGenreSimpleServiceResponse> genres,
-    List<ShowTicketingTimeServiceParam> showTicketingTimes
+    String image,
+    boolean onlyOpenSchedule
 ) {
+    public static ShowPaginationServiceResponse of(
+        ShowTicketingDomainResponse response,
+        boolean onlyOpenSchedule
+    ) {
+        LocalDateTime now = LocalDateTime.now();
 
-    public static ShowPaginationServiceResponse from(ShowDetailDomainResponse response, LocalDateTime now) {
-        List<ShowTicketingTimeServiceParam> ticketingTimes = response.showTicketingTimes().stream()
-            .map(ShowTicketingTimeServiceParam::from)
-            .toList();
-
-        Optional<ShowTicketingTimeServiceParam> optShowTicketingTime = ticketingTimes.stream()
-            .filter(ticketingTime -> now.isBefore(ticketingTime.ticketingAt()))
-            .findFirst();
-
-        String reservationAt = optShowTicketingTime.map(
-            showTicketingTime -> DateTimeUtil.formatDateTime(showTicketingTime.ticketingAt())
-        ).orElseGet(() -> "");
+        if (onlyOpenSchedule && response.ticketingAt().isBefore(now)) {
+            return null;
+        }
 
         return ShowPaginationServiceResponse.builder()
-            .id(response.show().id())
-            .title(response.show().title())
-            .location(response.show().location())
-            .posterImageURL(response.show().image())
-            .reservationAt(reservationAt)
-            .hasTicketingOpenSchedule(now.isBefore(response.show().lastTicketingAt()))
-            .viewCount(response.show().viewCount())
-            .artists(
-                response.artists().stream()
-                    .map(ShowArtistSimpleServiceResponse::from)
-                    .toList()
-            )
-            .genres(
-                response.genres().stream()
-                    .map(ShowGenreSimpleServiceResponse::from)
-                    .toList()
-            )
-            .showTicketingTimes(ticketingTimes)
+            .id(response.id())
+            .title(response.title())
+            .ticketingAt(response.ticketingAt())
+            .location(response.location())
+            .image(response.image())
+            .onlyOpenSchedule(response.ticketingAt().isAfter(now))
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/service/dto/response/ShowPaginationServiceResponse.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/dto/response/ShowPaginationServiceResponse.java
@@ -1,5 +1,6 @@
 package com.example.show.service.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
@@ -21,6 +22,10 @@ public record ShowPaginationServiceResponse(
         LocalDateTime now = LocalDateTime.now();
 
         if (onlyOpenSchedule && response.ticketingAt().isBefore(now)) {
+            return null;
+        }
+
+        if (!onlyOpenSchedule && response.endDate().isBefore(LocalDate.now())) {
             return null;
         }
 

--- a/app/domain/show-domain/src/main/java/org/example/dto/show/request/ShowPaginationDomainRequest.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/show/request/ShowPaginationDomainRequest.java
@@ -10,7 +10,6 @@ public record ShowPaginationDomainRequest(
     ShowSortType sort,
     boolean onlyOpenSchedule,
     UUID cursorId,
-    Object cursorValue,
     int size,
     LocalDateTime now
 ) {

--- a/app/domain/show-domain/src/main/java/org/example/dto/show/response/ShowTicketingDomainResponse.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/show/response/ShowTicketingDomainResponse.java
@@ -1,11 +1,13 @@
 package org.example.dto.show.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record ShowTicketingDomainResponse(
     UUID id,
     String title,
+    LocalDate endDate,
     LocalDateTime ticketingAt,
     String location,
     String image

--- a/app/domain/show-domain/src/main/java/org/example/dto/show/response/ShowTicketingDomainResponse.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/show/response/ShowTicketingDomainResponse.java
@@ -1,0 +1,14 @@
+package org.example.dto.show.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ShowTicketingDomainResponse(
+    UUID id,
+    String title,
+    LocalDateTime ticketingAt,
+    String location,
+    String image
+) {
+
+}

--- a/app/domain/show-domain/src/main/java/org/example/dto/show/response/ShowTicketingPaginationDomainResponse.java
+++ b/app/domain/show-domain/src/main/java/org/example/dto/show/response/ShowTicketingPaginationDomainResponse.java
@@ -1,0 +1,12 @@
+package org.example.dto.show.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ShowTicketingPaginationDomainResponse(
+    List<ShowTicketingDomainResponse> data,
+    boolean hasNext
+) {
+
+}

--- a/app/domain/show-domain/src/main/java/org/example/repository/show/ShowQuerydslRepository.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/show/ShowQuerydslRepository.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import org.example.dto.show.request.ShowPaginationDomainRequest;
 import org.example.dto.show.response.ShowDetailDomainResponse;
 import org.example.dto.show.response.ShowInfoDomainResponse;
-import org.example.dto.show.response.ShowPaginationDomainResponse;
+import org.example.dto.show.response.ShowTicketingPaginationDomainResponse;
 import org.example.dto.show.response.ShowWithTicketingTimesDomainResponse;
 
 public interface ShowQuerydslRepository {
@@ -16,7 +16,7 @@ public interface ShowQuerydslRepository {
 
     List<ShowWithTicketingTimesDomainResponse> findShowDetailWithTicketingTimes();
 
-    ShowPaginationDomainResponse findShows(ShowPaginationDomainRequest request);
+    ShowTicketingPaginationDomainResponse findShows(ShowPaginationDomainRequest request);
 
     Optional<ShowInfoDomainResponse> findShowInfoById(UUID id);
 

--- a/app/domain/show-domain/src/main/java/org/example/repository/show/ShowQuerydslRepositoryImpl.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/show/ShowQuerydslRepositoryImpl.java
@@ -113,6 +113,7 @@ public class ShowQuerydslRepositoryImpl implements ShowQuerydslRepository {
                     ShowTicketingDomainResponse.class,
                     show.id,
                     show.title,
+                    show.endDate,
                     showTicketingTime.ticketingAt,
                     show.location,
                     show.image

--- a/app/domain/show-domain/src/main/java/org/example/repository/show/ShowQuerydslRepositoryImpl.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/show/ShowQuerydslRepositoryImpl.java
@@ -10,10 +10,10 @@ import static org.example.entity.show.QShowArtist.showArtist;
 import static org.example.entity.show.QShowGenre.showGenre;
 import static org.example.entity.show.QShowTicketingTime.showTicketingTime;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.ConstructorExpression;
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.OrderSpecifier.NullHandling;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -31,11 +31,11 @@ import org.example.dto.show.request.ShowPaginationDomainRequest;
 import org.example.dto.show.response.ShowDetailDomainResponse;
 import org.example.dto.show.response.ShowDomainResponse;
 import org.example.dto.show.response.ShowInfoDomainResponse;
-import org.example.dto.show.response.ShowPaginationDomainResponse;
+import org.example.dto.show.response.ShowTicketingDomainResponse;
+import org.example.dto.show.response.ShowTicketingPaginationDomainResponse;
 import org.example.dto.show.response.ShowTicketingTimeDomainResponse;
 import org.example.dto.show.response.ShowWithTicketingTimesDomainResponse;
 import org.example.entity.show.Show;
-import org.example.util.DateTimeUtil;
 import org.example.util.SliceUtil;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
@@ -106,16 +106,28 @@ public class ShowQuerydslRepositoryImpl implements ShowQuerydslRepository {
     }
 
     @Override
-    public ShowPaginationDomainResponse findShows(ShowPaginationDomainRequest request) {
-        List<ShowDetailDomainResponse> result;
-        switch (request.sort()) {
-            case POPULAR -> result = findShowsByPopularity(request);
-            default -> result = findShowsByClosestTicketingAt(request);
-        }
+    public ShowTicketingPaginationDomainResponse findShows(ShowPaginationDomainRequest request) {
+        List<ShowTicketingDomainResponse> result = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    ShowTicketingDomainResponse.class,
+                    show.id,
+                    show.title,
+                    showTicketingTime.ticketingAt,
+                    show.location,
+                    show.image
+                )
+            )
+            .from(show)
+            .join(showTicketingTime).on(showTicketingTime.show.id.eq(show.id))
+            .where(getShowAlertsInCursorPagination(request))
+            .orderBy(getOrderSpecifier(request))
+            .limit(request.size() + 1)
+            .fetch();
 
-        Slice<ShowDetailDomainResponse> slice = SliceUtil.makeSlice(request.size(), result);
+        Slice<ShowTicketingDomainResponse> slice = SliceUtil.makeSlice(request.size(), result);
 
-        return ShowPaginationDomainResponse.builder()
+        return ShowTicketingPaginationDomainResponse.builder()
             .data(slice.getContent())
             .hasNext(slice.hasNext())
             .build();
@@ -136,89 +148,68 @@ public class ShowQuerydslRepositoryImpl implements ShowQuerydslRepository {
         return result == null ? 0 : result;
     }
 
-    private List<ShowDetailDomainResponse> findShowsByPopularity(
-        ShowPaginationDomainRequest request) {
-        BooleanExpression whereExpression = show.isDeleted.isFalse();
+    private Predicate getShowAlertsInCursorPagination(ShowPaginationDomainRequest request) {
+        BooleanExpression wherePredicate = getDefaultPredicateExpression();
 
-        if (request.cursorId() != null) {
-            whereExpression.and(
-                show.viewCount.gt(Integer.parseInt(request.cursorValue().toString()))
-                    .or(show.viewCount.eq(Integer.parseInt(request.cursorValue().toString()))
-                        .and(show.id.gt(request.cursorId()))
-                    )
-            );
+        if (request.cursorId() == null) {
+            return wherePredicate;
         }
 
-        if (request.onlyOpenSchedule()) {
-            whereExpression.and(show.lastTicketingAt.after(request.now()));
+        switch (request.sort()) {
+            case RECENT -> {
+                return wherePredicate.and(createRecentPredicate(request.cursorId()));
+            }
+            default -> {
+                return wherePredicate.and(createPopularPredicate(request.cursorId()));
+            }
         }
-
-        return jpaQueryFactory
-            .selectFrom(show)
-            .leftJoin(showArtist).on(isShowArtistEqualShowIdAndIsDeletedFalse())
-            .leftJoin(artist).on(isArtistIdEqualShowArtistAndIsDeletedFalse())
-            .leftJoin(showGenre).on(isShowGenreEqualShowIdAndIsDeletedFalse())
-            .leftJoin(genre).on(isGenreIdEqualShowGenreAndIsDeletedFalse())
-            .leftJoin(showTicketingTime)
-            .on(showTicketingTime.show.id.eq(show.id).and(showTicketingTime.isDeleted.isFalse()))
-            .where(whereExpression)
-            .limit(request.size() + 1)
-            .orderBy(
-                show.viewCount.desc(),
-                show.id.asc()
-            )
-            .transform(
-                groupBy(show.id).as(getShowDetailConstructor())
-            ).values().stream()
-            .toList();
     }
 
-    private List<ShowDetailDomainResponse> findShowsByClosestTicketingAt(
-        ShowPaginationDomainRequest request) {
-        JPAQuery<LocalDateTime> closestTicketingTimeQuery = jpaQueryFactory
-            .select(showTicketingTime.ticketingAt.min())
+    private BooleanExpression getDefaultPredicateExpression() {
+        return show.isDeleted.isFalse().and(showTicketingTime.isDeleted.isFalse());
+    }
+
+    private BooleanExpression createRecentPredicate(UUID cursorId) {
+        Tuple cursor = jpaQueryFactory
+            .select(showTicketingTime.id, showTicketingTime.ticketingAt)
             .from(showTicketingTime)
-            .where(showTicketingTime.show.id.eq(show.id)
-                .and(showTicketingTime.ticketingAt.gt(request.now())));
+            .where(showTicketingTime.show.id.eq(cursorId))
+            .fetchFirst();
 
-        BooleanExpression whereExpression = show.isDeleted.isFalse()
-            .and(closestTicketingTimeQuery.isNotNull());
+        LocalDateTime cursorValue = cursor.get(showTicketingTime.ticketingAt);
+        UUID cursorIdValue = cursor.get(showTicketingTime.id);
 
-        if (request.cursorId() != null) {
-            whereExpression.and(
-                closestTicketingTimeQuery.gt(
-                        DateTimeUtil.parseDateTime(request.cursorValue().toString()))
-                    .or(closestTicketingTimeQuery.eq(
-                            DateTimeUtil.parseDateTime(request.cursorValue().toString()))
-                        .and(show.id.gt(request.cursorId()))
-                    )
-            );
-        }
+        return showTicketingTime.ticketingAt.gt(cursorValue)
+            .or(showTicketingTime.ticketingAt.eq(cursorValue)
+                .and(showTicketingTime.id.gt(cursorIdValue)));
+    }
 
-        if (request.onlyOpenSchedule()) {
-            whereExpression.and(show.lastTicketingAt.after(request.now()));
-        }
+    private BooleanExpression createPopularPredicate(UUID cursorId) {
+        Tuple cursor = jpaQueryFactory
+            .select(show.id, show.viewCount)
+            .from(show)
+            .where(show.id.eq(cursorId))
+            .fetchFirst();
 
-        List<ShowDetailDomainResponse> response = jpaQueryFactory
-            .selectFrom(show)
-            .leftJoin(showGenre).on(show.id.eq(showGenre.showId).and(showGenre.isDeleted.isFalse()))
-            .leftJoin(genre).on(showGenre.genreId.eq(genre.id).and(genre.isDeleted.isFalse()))
-            .leftJoin(showArtist)
-            .on(show.id.eq(showArtist.showId).and(showArtist.isDeleted.isFalse()))
-            .leftJoin(artist).on(showArtist.artistId.eq(artist.id).and(artist.isDeleted.isFalse()))
-            .leftJoin(showTicketingTime)
-            .on(show.id.eq(showTicketingTime.show.id).and(showTicketingTime.isDeleted.isFalse()))
-            .where(whereExpression)
-            .limit(request.size() + 1)
-            .orderBy(
-                new OrderSpecifier<>(Order.ASC, closestTicketingTimeQuery, NullHandling.NullsLast),
+        Integer cursorValue = cursor.get(show.viewCount);
+        UUID cursorIdValue = cursor.get(show.id);
+
+        return show.viewCount.lt(cursorValue)
+            .or(show.viewCount.eq(cursorValue)
+                .and(show.id.gt(cursorIdValue)));
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifier(ShowPaginationDomainRequest request) {
+        return switch (request.sort()) {
+            case RECENT -> new OrderSpecifier<?>[]{
+                showTicketingTime.ticketingAt.asc(),
+                showTicketingTime.id.asc()
+            };
+            default -> new OrderSpecifier<?>[]{
+                show.viewCount.desc(),
                 show.id.asc()
-            )
-            .transform(
-                groupBy(show.id).as(getShowDetailConstructor())
-            ).values().stream().toList();
-
-        return response;
+            };
+        };
     }
 
     private ConstructorExpression<ShowDetailDomainResponse> getShowDetailConstructor() {

--- a/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
@@ -10,8 +10,8 @@ import org.example.dto.show.request.ShowPaginationDomainRequest;
 import org.example.dto.show.request.ShowSearchPaginationDomainRequest;
 import org.example.dto.show.response.ShowAlertPaginationDomainResponse;
 import org.example.dto.show.response.ShowDetailDomainResponse;
-import org.example.dto.show.response.ShowPaginationDomainResponse;
 import org.example.dto.show.response.ShowSearchPaginationDomainResponse;
+import org.example.dto.show.response.ShowTicketingPaginationDomainResponse;
 import org.example.entity.show.Show;
 import org.example.entity.show.ShowTicketingTime;
 import org.example.repository.show.ShowRepository;
@@ -33,7 +33,7 @@ public class ShowUseCase {
         return showRepository.findShowDetailById(id).orElseThrow(NoSuchElementException::new);
     }
 
-    public ShowPaginationDomainResponse findShows(ShowPaginationDomainRequest request) {
+    public ShowTicketingPaginationDomainResponse findShows(ShowPaginationDomainRequest request) {
         return showRepository.findShows(request);
     }
 


### PR DESCRIPTION
## 😋 작업한 내용

- 공연 목록 조회 시 인기순, 임박순 기준 정렬 후 무한 스크롤을 적용했습니다. 
- CursorValue를 front에 넘겨주는 방식으로 해보면 서브쿼리를 줄일 수 있는 장점으로 이전에는 그렇게 정하였는데요, 지금 같은 경우는 인기순, 임박순의 cursorValue 타입이 다르니 서브쿼리로 cursorValue를 찾아 해결 했습니다. 찬기님 말씀대로 정렬 하는 무한 스크롤 방식을 다시 한번 생각해봐야겠어요 ㅠㅡㅠ. 걍 서브쿼리가 맞는것 같기도 하고..? ㅎ.ㅎ 이건 이후에 논의해봐용
- 응답 필드를 필요한 데이터에 맞게 수정했습니다.

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #135 


---