### PR TITLE
fix: 공연 티켓팅 알림, 관심 등록 예외 처리 추가

### DIFF
--- a/app/api/show-api/src/main/java/com/example/show/error/ShowError.java
+++ b/app/api/show-api/src/main/java/com/example/show/error/ShowError.java
@@ -4,10 +4,10 @@ import org.example.exception.BusinessError;
 
 public enum ShowError implements BusinessError {
 
-    ENTITY_NOT_FOUND {
+    TICKETING_ALERT_RESERVED_ERROR {
         @Override
         public int getHttpStatus() {
-            return 404;
+            return 400;
         }
 
         @Override
@@ -17,12 +17,12 @@ public enum ShowError implements BusinessError {
 
         @Override
         public String getClientMessage() {
-            return "해당 공연을 찾을 수 없습니다.";
+            return "해당 공연의 티켓팅 알림을 설정할 수 없습니다.";
         }
 
         @Override
         public String getLogMessage() {
-            return "공연 ID에 매칭되는 정보를 찾을 수 없습니다.";
+            return "해당 공연의 티켓팅 시간에 설정할 수 있는 알림 시간이 없습니다.";
         }
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
@@ -54,7 +54,7 @@ public class ShowService {
         ShowDetailDomainResponse showDetail = showUseCase.findShowDetail(showId);
 
         boolean isInterested =
-            userId != null && userShowUseCase.findByShowIdAndUserId(showId, userId).isPresent();
+            userId != null && userShowUseCase.findInterestShow(showId, userId).isPresent();
 
         if (viewCountComponent.validateViewCount(showId, viewIdentifier)) {
             showUseCase.view(showId);

--- a/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
@@ -111,8 +111,10 @@ public class ShowService {
     }
 
     public ShowInterestServiceResponse interest(ShowInterestServiceRequest request) {
+        Show show = showUseCase.findShowOrThrowNoSuchElementException(request.showId());
+
         return ShowInterestServiceResponse.from(
-            userShowUseCase.interest(request.toDomainRequest())
+            userShowUseCase.interest(request.toDomainRequest(show.getId()))
         );
     }
 

--- a/app/api/show-api/src/main/java/com/example/show/service/dto/request/ShowInterestServiceRequest.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/dto/request/ShowInterestServiceRequest.java
@@ -10,9 +10,9 @@ public record ShowInterestServiceRequest(
     UUID userId
 ) {
 
-    public InterestShowDomainRequest toDomainRequest() {
+    public InterestShowDomainRequest toDomainRequest(UUID showId) {
         return InterestShowDomainRequest.builder()
-            .showId(showId())
+            .showId(showId)
             .userId(userId())
             .build();
     }

--- a/app/api/show-api/src/main/java/com/example/show/service/dto/response/InterestShowPaginationServiceResponse.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/dto/response/InterestShowPaginationServiceResponse.java
@@ -28,7 +28,7 @@ public record InterestShowPaginationServiceResponse(
             .interestShowId(interestShow.getId())
             .interestedAt(interestShow.getUpdatedAt())
             .title(show.getTitle())
-            .location(show.getTitle())
+            .location(show.getLocation())
             .posterImageURL(show.getImage())
             .startAt(show.getStartDate())
             .endAt(show.getEndDate())

--- a/app/domain/show-domain/src/main/java/org/example/repository/show/ShowRepository.java
+++ b/app/domain/show-domain/src/main/java/org/example/repository/show/ShowRepository.java
@@ -1,6 +1,7 @@
 package org.example.repository.show;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.example.entity.show.Show;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ShowRepository extends JpaRepository<Show, UUID>, ShowQuerydslRepository {
 
     List<Show> findShowsByIdIn(List<UUID> showIds);
+
+    Optional<Show> findByIdAndIsDeletedFalse(UUID showId);
 }

--- a/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
@@ -79,6 +79,6 @@ public class ShowUseCase {
     }
 
     public Show findShowOrThrowNoSuchElementException(UUID id) {
-        return showRepository.findById(id).orElseThrow(NoSuchElementException::new);
+        return showRepository.findByIdAndIsDeletedFalse(id).orElseThrow(NoSuchElementException::new);
     }
 }

--- a/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
+++ b/app/domain/show-domain/src/main/java/org/example/usecase/show/ShowUseCase.java
@@ -78,7 +78,7 @@ public class ShowUseCase {
         return showRepository.findTerminatedTicketingShowsCount(showIds, now);
     }
 
-    private Show findShowOrThrowNoSuchElementException(UUID id) {
+    public Show findShowOrThrowNoSuchElementException(UUID id) {
         return showRepository.findById(id).orElseThrow(NoSuchElementException::new);
     }
 }

--- a/app/domain/user-domain/src/main/java/org/example/repository/interest/InterestShowRepository.java
+++ b/app/domain/user-domain/src/main/java/org/example/repository/interest/InterestShowRepository.java
@@ -9,5 +9,7 @@ public interface InterestShowRepository extends JpaRepository<InterestShow, UUID
 
     Optional<InterestShow> findByShowIdAndUserId(UUID showId, UUID userId);
 
+    Optional<InterestShow> findByShowIdAndUserIdAndIsDeletedFalse(UUID showId, UUID userId);
+
     Long countInterestShowByUserIdAndIsDeletedFalse(UUID userId);
 }

--- a/app/domain/user-domain/src/main/java/org/example/usecase/UserShowUseCase.java
+++ b/app/domain/user-domain/src/main/java/org/example/usecase/UserShowUseCase.java
@@ -26,7 +26,7 @@ public class UserShowUseCase {
 
     @Transactional
     public InterestShow interest(InterestShowDomainRequest request) {
-        Optional<InterestShow> optInterestShow = findByShowIdAndUserId(request.showId(), request.userId());
+        Optional<InterestShow> optInterestShow = findInterestShowByShowIdAndUserId(request.showId(), request.userId());
 
         if (optInterestShow.isEmpty()) {
             return interestShowRepository.save(
@@ -43,8 +43,8 @@ public class UserShowUseCase {
         return interestShow;
     }
 
-    public Optional<InterestShow> findByShowIdAndUserId(UUID showId, UUID userId) {
-        return interestShowRepository.findByShowIdAndUserId(showId, userId);
+    public Optional<InterestShow> findInterestShow(UUID showId, UUID userId) {
+        return interestShowRepository.findByShowIdAndUserIdAndIsDeletedFalse(showId, userId);
     }
 
     public List<ArtistSubscription> findArtistSubscriptionByUserId(UUID userId) {
@@ -72,5 +72,9 @@ public class UserShowUseCase {
     public long countInterestShows(UUID userId) {
         Long result = interestShowRepository.countInterestShowByUserIdAndIsDeletedFalse(userId);
         return result == null ? 0 : result;
+    }
+
+    private Optional<InterestShow> findInterestShowByShowIdAndUserId(UUID showId, UUID userId) {
+        return interestShowRepository.findByShowIdAndUserId(showId, userId);
     }
 }


### PR DESCRIPTION
## 😋 작업한 내용

- 공연 관심 등록 시 공연 ID에 따른 공연이 존재하는지 확인 로직을 추가하였습니다.
- 공연 티켓팅 알림 등록 시 아예 등록할 수 없으면 예외를 던지게 수정하였습니다.

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #146 


---