### PR TITLE
fix: 공연 알림 설정 수정

### DIFF
--- a/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
+++ b/app/api/show-api/src/main/java/com/example/show/service/ShowService.java
@@ -151,16 +151,16 @@ public class ShowService {
             ticketingAlertReservationRequest.type().toDomainType()
         );
 
-        var request = ticketingAlertReservationRequest.toDomainRequest(
-            showTicketingTime.getShow().getTitle(),
-            showTicketingTime.getTicketingAt()
-        );
-
-        if (request.alertTimes().isEmpty()) {
+        if (showTicketingTime.getTicketingAt().isBefore(LocalDateTime.now())) {
             throw new BusinessException(ShowError.TICKETING_ALERT_RESERVED_ERROR);
         }
 
-        var domainResponse = ticketingAlertUseCase.alertReservation(request);
+        var domainResponse = ticketingAlertUseCase.alertReservation(
+            ticketingAlertReservationRequest.toDomainRequest(
+                showTicketingTime.getShow().getTitle(),
+                showTicketingTime.getTicketingAt()
+            )
+        );
         messagePublisher.publishTicketingReservation(
             "ticketingAlert",
             TicketingAlertsToReserveServiceMessage.from(domainResponse)


### PR DESCRIPTION
## 😋 작업한 내용

-알림 설정 시 현재 시간으로부터 이미 지난 티켓팅 시간을 가진 공연은 알림 등록 할 수 없도록 수정

## 🙏 PR Point

-

## 👍 관련 이슈

- Resolved : #


---