### PR TITLE
fix: dev 데이터 환경 초기화 삭제

### DIFF
--- a/app/domain/common-domain/src/main/resources/application-domain-dev.yml
+++ b/app/domain/common-domain/src/main/resources/application-domain-dev.yml
@@ -4,7 +4,7 @@ spring:
       ddl-auto: none
     show-sql: true
     open-in-view: false
-    generate-ddl: true
+    generate-ddl: false
     defer-datasource-initialization: true
     properties:
       hibernate:

--- a/app/domain/common-domain/src/main/resources/application-domain-dev.yml
+++ b/app/domain/common-domain/src/main/resources/application-domain-dev.yml
@@ -19,4 +19,4 @@ spring:
 
   sql:
     init:
-      mode: always
+      mode: never

--- a/app/domain/common-domain/src/main/resources/application-domain-dev.yml
+++ b/app/domain/common-domain/src/main/resources/application-domain-dev.yml
@@ -5,7 +5,7 @@ spring:
     show-sql: true
     open-in-view: false
     generate-ddl: false
-    defer-datasource-initialization: true
+    defer-datasource-initialization: false
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 😋 작업한 내용

- dev 환경 데이터 초기화 삭제
- alarm 서버에서 prod 환경에서 APPLICATION_DATASOURCE_URL_PROD을 넣어주지 않아 github action에서 키를 넣어주었습니다. 

## 🙏 PR Point

- dev만 sql init을 삭제하면 될까요?
- 추가로 prod 환경의 CI/CD는 prod 브랜치에 배포되었을 때 trigger로 발생되는데, prod 브랜치는 없애고, main 브랜치로 머지가 될 때 실행되는 건 어떻게 생각하시나용?

## 👍 관련 이슈

- Resolved : #152 


---