### PR TITLE
fix : cursor 응답 스키마 변경

### DIFF
--- a/app/api/common-api/src/main/java/org/example/dto/response/CursorApiResponse.java
+++ b/app/api/common-api/src/main/java/org/example/dto/response/CursorApiResponse.java
@@ -1,6 +1,7 @@
 package org.example.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import java.util.UUID;
 
 public record CursorApiResponse(
@@ -11,6 +12,7 @@ public record CursorApiResponse(
     @Schema(description = "조회한 데이터의 Cursor Value")
     Object value
 ) {
+
     public static CursorApiResponse toCursorResponse(UUID id, Object value) {
         return new CursorApiResponse(id, value);
     }
@@ -19,4 +21,11 @@ public record CursorApiResponse(
         return new CursorApiResponse(id, "");
     }
 
+    public static CursorApiResponse noneCursor() {
+        return new CursorApiResponse(null, "");
+    }
+
+    public static <T> T getLastElement(List<T> list) {
+        return list.isEmpty() ? null : list.get(list.size() - 1);
+    }
 }

--- a/app/api/common-api/src/main/java/org/example/dto/response/CursorApiResponse.java
+++ b/app/api/common-api/src/main/java/org/example/dto/response/CursorApiResponse.java
@@ -18,11 +18,11 @@ public record CursorApiResponse(
     }
 
     public static CursorApiResponse toCursorId(UUID id) {
-        return new CursorApiResponse(id, "");
+        return new CursorApiResponse(id, null);
     }
 
     public static CursorApiResponse noneCursor() {
-        return new CursorApiResponse(null, "");
+        return new CursorApiResponse(null, null);
     }
 
     public static <T> T getLastElement(List<T> list) {

--- a/app/api/common-api/src/main/java/org/example/dto/response/PaginationApiResponse.java
+++ b/app/api/common-api/src/main/java/org/example/dto/response/PaginationApiResponse.java
@@ -10,14 +10,17 @@ public record PaginationApiResponse<T>(
     @Schema(description = "다음 조회 가능 여부")
     boolean hasNext,
     @Schema(description = "조회 데이터")
-    List<T> data
+    List<T> data,
+    @Schema(description = "조회 데이터의 cursor")
+    CursorApiResponse cursor
 ) {
 
     @Builder
     public PaginationApiResponse(
         List<T> data,
-        boolean hasNext
+        boolean hasNext,
+        CursorApiResponse cursor
     ) {
-        this(data.size(), hasNext, data);
+        this(data.size(), hasNext, data, cursor);
     }
 }

--- a/app/api/show-api/src/main/java/com/example/artist/controller/ArtistController.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/ArtistController.java
@@ -17,8 +17,10 @@ import com.example.artist.service.ArtistService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.example.dto.response.CursorApiResponse;
 import org.example.dto.response.PaginationApiResponse;
 import org.example.security.dto.AuthenticatedInfo;
 import org.example.util.ValidatorUser;
@@ -52,10 +54,15 @@ public class ArtistController {
             .map(ArtistUnsubscriptionPaginationApiParam::from)
             .toList();
 
+        CursorApiResponse cursor = Optional.ofNullable(CursorApiResponse.getLastElement(data))
+            .map(element -> CursorApiResponse.toCursorId(element.id()))
+            .orElse(CursorApiResponse.noneCursor());
+
         return ResponseEntity.ok(
             PaginationApiResponse.<ArtistUnsubscriptionPaginationApiParam>builder()
                 .hasNext(response.hasNext())
                 .data(data)
+                .cursor(cursor)
                 .build()
         );
     }
@@ -73,10 +80,15 @@ public class ArtistController {
             .map(ArtistSubscriptionPaginationApiParam::from)
             .toList();
 
+        CursorApiResponse cursor = Optional.ofNullable(CursorApiResponse.getLastElement(data))
+            .map(element -> CursorApiResponse.toCursorId(element.id()))
+            .orElse(CursorApiResponse.noneCursor());
+
         return ResponseEntity.ok(
             PaginationApiResponse.<ArtistSubscriptionPaginationApiParam>builder()
                 .hasNext(response.hasNext())
                 .data(data)
+                .cursor(cursor)
                 .build()
         );
     }
@@ -131,10 +143,15 @@ public class ArtistController {
             .map(ArtistSearchPaginationApiParam::from)
             .toList();
 
+        CursorApiResponse cursor = Optional.ofNullable(CursorApiResponse.getLastElement(data))
+            .map(element -> CursorApiResponse.toCursorId(element.id()))
+            .orElse(CursorApiResponse.noneCursor());
+
         return ResponseEntity.ok(
             PaginationApiResponse.<ArtistSearchPaginationApiParam>builder()
                 .hasNext(response.hasNext())
                 .data(data)
+                .cursor(cursor)
                 .build()
         );
     }

--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistSearchPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistSearchPaginationApiParam.java
@@ -2,11 +2,11 @@ package com.example.artist.controller.dto.param;
 
 import com.example.artist.service.dto.param.ArtistSearchPaginationServiceParam;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.example.dto.response.CursorApiResponse;
+import java.util.UUID;
 
 public record ArtistSearchPaginationApiParam(
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor,
+    @Schema(description = "아티스트 ID")
+    UUID id,
 
     @Schema(description = "아티스트 이미지 URL")
     String imageURL,
@@ -23,7 +23,7 @@ public record ArtistSearchPaginationApiParam(
 
     public static ArtistSearchPaginationApiParam from(ArtistSearchPaginationServiceParam param) {
         return new ArtistSearchPaginationApiParam(
-            CursorApiResponse.toCursorId(param.artistId()),
+            param.artistId(),
             param.artistImageUrl(),
             param.artistKoreanName(),
             param.artistEnglishName(),

--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistSubscriptionPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistSubscriptionPaginationApiParam.java
@@ -2,11 +2,11 @@ package com.example.artist.controller.dto.param;
 
 import com.example.artist.service.dto.param.ArtistSubscriptionPaginationServiceParam;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.example.dto.response.CursorApiResponse;
+import java.util.UUID;
 
 public record ArtistSubscriptionPaginationApiParam(
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor,
+    @Schema(description = "아티스트 ID")
+    UUID id,
     @Schema(description = "아티스트 이미지 URL")
     String imageURL,
     @Schema(description = "아티스트 한글 이름")
@@ -15,11 +15,9 @@ public record ArtistSubscriptionPaginationApiParam(
     String englishName
 ) {
 
-    public static ArtistSubscriptionPaginationApiParam from(
-        ArtistSubscriptionPaginationServiceParam param
-    ) {
+    public static ArtistSubscriptionPaginationApiParam from(ArtistSubscriptionPaginationServiceParam param) {
         return new ArtistSubscriptionPaginationApiParam(
-            CursorApiResponse.toCursorId(param.artistId()),
+            param.artistId(),
             param.artistImageUrl(),
             param.artistKoreanName(),
             param.artistEnglishName()

--- a/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistUnsubscriptionPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/artist/controller/dto/param/ArtistUnsubscriptionPaginationApiParam.java
@@ -2,11 +2,11 @@ package com.example.artist.controller.dto.param;
 
 import com.example.artist.service.dto.param.ArtistUnsubscriptionPaginationServiceParam;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.example.dto.response.CursorApiResponse;
+import java.util.UUID;
 
 public record ArtistUnsubscriptionPaginationApiParam(
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor,
+    @Schema(description = "아티스트 ID")
+    UUID id,
     @Schema(description = "아티스트 이미지 URL")
     String imageURL,
     @Schema(description = "아티스트 한글 이름")
@@ -19,7 +19,7 @@ public record ArtistUnsubscriptionPaginationApiParam(
         ArtistUnsubscriptionPaginationServiceParam param
     ) {
         return new ArtistUnsubscriptionPaginationApiParam(
-            CursorApiResponse.toCursorId(param.artistId()),
+            param.artistId(),
             param.artistImageUrl(),
             param.artistKoreanName(),
             param.artistEnglishName()

--- a/app/api/show-api/src/main/java/com/example/genre/controller/GenreController.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/GenreController.java
@@ -15,8 +15,10 @@ import com.example.genre.service.GenreService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.example.dto.response.CursorApiResponse;
 import org.example.dto.response.PaginationApiResponse;
 import org.example.security.dto.AuthenticatedInfo;
 import org.example.util.ValidatorUser;
@@ -49,10 +51,15 @@ public class GenreController {
             .map(GenrePaginationApiParam::new)
             .toList();
 
+        CursorApiResponse cursor = Optional.ofNullable(CursorApiResponse.getLastElement(data))
+            .map(element -> CursorApiResponse.toCursorId(element.id()))
+            .orElse(CursorApiResponse.noneCursor());
+
         return ResponseEntity.ok(
             PaginationApiResponse.<GenrePaginationApiParam>builder()
                 .hasNext(response.hasNext())
                 .data(data)
+                .cursor(cursor)
                 .build()
         );
     }
@@ -70,10 +77,15 @@ public class GenreController {
             .map(GenreUnsubscriptionPaginationApiParam::new)
             .toList();
 
+        CursorApiResponse cursor = Optional.ofNullable(CursorApiResponse.getLastElement(data))
+            .map(element -> CursorApiResponse.toCursorId(element.id()))
+            .orElse(CursorApiResponse.noneCursor());
+
         return ResponseEntity.ok(
             PaginationApiResponse.<GenreUnsubscriptionPaginationApiParam>builder()
                 .hasNext(response.hasNext())
                 .data(data)
+                .cursor(cursor)
                 .build()
         );
     }
@@ -91,10 +103,15 @@ public class GenreController {
             .map(GenreSubscriptionPaginationApiParam::new)
             .toList();
 
+        CursorApiResponse cursor = Optional.ofNullable(CursorApiResponse.getLastElement(data))
+            .map(element -> CursorApiResponse.toCursorId(element.id()))
+            .orElse(CursorApiResponse.noneCursor());
+
         return ResponseEntity.ok(
             PaginationApiResponse.<GenreSubscriptionPaginationApiParam>builder()
                 .hasNext(response.hasNext())
                 .data(data)
+                .cursor(cursor)
                 .build()
         );
     }

--- a/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenrePaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenrePaginationApiParam.java
@@ -2,12 +2,12 @@ package com.example.genre.controller.dto.param;
 
 import com.example.genre.service.dto.param.GenrePaginationServiceParam;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.example.dto.response.CursorApiResponse;
+import java.util.UUID;
 
 public record GenrePaginationApiParam(
 
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor,
+    @Schema(description = "장르 ID")
+    UUID id,
 
     @Schema(description = "장르 이름")
     String name,
@@ -18,7 +18,7 @@ public record GenrePaginationApiParam(
 
     public GenrePaginationApiParam(GenrePaginationServiceParam param) {
         this(
-            CursorApiResponse.toCursorId(param.id()),
+            param.id(),
             param.name(),
             param.isSubscribed()
         );

--- a/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenreSubscriptionPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenreSubscriptionPaginationApiParam.java
@@ -1,14 +1,10 @@
 package com.example.genre.controller.dto.param;
 
 import com.example.genre.service.dto.param.GenreSubscriptionPaginationServiceParam;
-import io.swagger.v3.oas.annotations.media.Schema;
-import org.example.dto.response.CursorApiResponse;
+import java.util.UUID;
 
 public record GenreSubscriptionPaginationApiParam(
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor,
-
-    @Schema(description = "장르 이름")
+    UUID id,
     String name
 ) {
 
@@ -16,7 +12,7 @@ public record GenreSubscriptionPaginationApiParam(
         GenreSubscriptionPaginationServiceParam response
     ) {
         this(
-            CursorApiResponse.toCursorId(response.id()),
+            response.id(),
             response.name()
         );
     }

--- a/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenreSubscriptionPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenreSubscriptionPaginationApiParam.java
@@ -1,10 +1,14 @@
 package com.example.genre.controller.dto.param;
 
 import com.example.genre.service.dto.param.GenreSubscriptionPaginationServiceParam;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 
 public record GenreSubscriptionPaginationApiParam(
+    @Schema(description = "장르 ID")
     UUID id,
+
+    @Schema(description = "장르 이름")
     String name
 ) {
 

--- a/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenreUnsubscriptionPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenreUnsubscriptionPaginationApiParam.java
@@ -1,14 +1,10 @@
 package com.example.genre.controller.dto.param;
 
 import com.example.genre.service.dto.param.GenreUnsubscriptionPaginationServiceParam;
-import io.swagger.v3.oas.annotations.media.Schema;
-import org.example.dto.response.CursorApiResponse;
+import java.util.UUID;
 
 public record GenreUnsubscriptionPaginationApiParam(
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor,
-
-    @Schema(description = "장르 이름")
+    UUID id,
     String name
 ) {
 
@@ -16,7 +12,7 @@ public record GenreUnsubscriptionPaginationApiParam(
         GenreUnsubscriptionPaginationServiceParam response
     ) {
         this(
-            CursorApiResponse.toCursorId(response.id()),
+            response.id(),
             response.name()
         );
     }

--- a/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenreUnsubscriptionPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/genre/controller/dto/param/GenreUnsubscriptionPaginationApiParam.java
@@ -1,10 +1,14 @@
 package com.example.genre.controller.dto.param;
 
 import com.example.genre.service.dto.param.GenreUnsubscriptionPaginationServiceParam;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 
 public record GenreUnsubscriptionPaginationApiParam(
+    @Schema(description = "장르 ID")
     UUID id,
+
+    @Schema(description = "장르 이름")
     String name
 ) {
 

--- a/app/api/show-api/src/main/java/com/example/show/controller/ShowController.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/ShowController.java
@@ -9,8 +9,10 @@ import com.example.show.service.ShowService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.example.dto.response.CursorApiResponse;
 import org.example.dto.response.PaginationApiResponse;
 import org.example.security.dto.AuthenticatedInfo;
 import org.example.util.ValidatorUser;
@@ -41,10 +43,15 @@ public class ShowController {
             .map(ShowPaginationApiParam::from)
             .toList();
 
+        CursorApiResponse cursor = Optional.ofNullable(CursorApiResponse.getLastElement(data))
+            .map(element -> CursorApiResponse.toCursorId(element.id()))
+            .orElse(CursorApiResponse.noneCursor());
+
         return ResponseEntity.ok(
             PaginationApiResponse.<ShowPaginationApiParam>builder()
                 .data(data)
                 .hasNext(response.hasNext())
+                .cursor(cursor)
                 .build()
         );
     }
@@ -69,15 +76,19 @@ public class ShowController {
         @Valid @ParameterObject ShowSearchPaginationApiRequest request
     ) {
         var response = showService.searchShow(request.toServiceRequest());
-
         var data = response.data().stream()
             .map(ShowSearchPaginationApiParam::from)
             .toList();
+
+        CursorApiResponse cursor = Optional.ofNullable(CursorApiResponse.getLastElement(data))
+            .map(element -> CursorApiResponse.toCursorId(element.id()))
+            .orElse(CursorApiResponse.noneCursor());
 
         return ResponseEntity.ok(
             PaginationApiResponse.<ShowSearchPaginationApiParam>builder()
                 .hasNext(response.hasNext())
                 .data(data)
+                .cursor(cursor)
                 .build()
         );
     }

--- a/app/api/show-api/src/main/java/com/example/show/controller/dto/param/ShowAlertPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/dto/param/ShowAlertPaginationApiParam.java
@@ -3,7 +3,6 @@ package com.example.show.controller.dto.param;
 import com.example.show.service.dto.param.ShowAlertPaginationServiceParam;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
-import org.example.dto.response.CursorApiResponse;
 import org.example.util.DateTimeUtil;
 
 public record ShowAlertPaginationApiParam(
@@ -26,10 +25,7 @@ public record ShowAlertPaginationApiParam(
     String location,
 
     @Schema(description = "공연 이미지 URL")
-    String imageURL,
-
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor
+    String imageURL
 ) {
 
     public static ShowAlertPaginationApiParam from(ShowAlertPaginationServiceParam serviceParam) {
@@ -40,8 +36,7 @@ public record ShowAlertPaginationApiParam(
             DateTimeUtil.formatDate(serviceParam.endAt()),
             DateTimeUtil.formatDateTime(serviceParam.ticketingAt()),
             serviceParam.location(),
-            serviceParam.image(),
-            CursorApiResponse.toCursorResponse(serviceParam.showTicketingTimeId(),  serviceParam.ticketingAt())
+            serviceParam.image()
         );
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/controller/dto/param/ShowSearchPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/dto/param/ShowSearchPaginationApiParam.java
@@ -2,12 +2,12 @@ package com.example.show.controller.dto.param;
 
 import com.example.show.service.dto.param.ShowSearchPaginationServiceParam;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.example.dto.response.CursorApiResponse;
+import java.util.UUID;
 import org.example.util.DateTimeUtil;
 
 public record ShowSearchPaginationApiParam(
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor,
+    @Schema(description = "공연 ID")
+    UUID id,
 
     @Schema(description = "공연 제목")
     String title,
@@ -27,7 +27,7 @@ public record ShowSearchPaginationApiParam(
 
     public static ShowSearchPaginationApiParam from(ShowSearchPaginationServiceParam serviceParam) {
         return new ShowSearchPaginationApiParam(
-            CursorApiResponse.toCursorId(serviceParam.id()),
+            serviceParam.id(),
             serviceParam.title(),
             DateTimeUtil.formatDate(serviceParam.startAt()),
             DateTimeUtil.formatDate(serviceParam.endAt()),

--- a/app/api/show-api/src/main/java/com/example/show/controller/dto/response/InterestShowPaginationApiResponse.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/dto/response/InterestShowPaginationApiResponse.java
@@ -4,7 +4,6 @@ import com.example.show.service.dto.response.InterestShowPaginationServiceRespon
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 import lombok.Builder;
-import org.example.dto.response.CursorApiResponse;
 import org.example.util.DateTimeUtil;
 
 @Builder
@@ -25,10 +24,7 @@ public record InterestShowPaginationApiResponse(
     String location,
 
     @Schema(description = "공연 포스터 이미지 주소")
-    String posterImageURL,
-
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor
+    String posterImageURL
 ) {
 
     public static InterestShowPaginationApiResponse from(
@@ -41,7 +37,6 @@ public record InterestShowPaginationApiResponse(
             .endAt(DateTimeUtil.formatDate(response.endAt()))
             .location(response.location())
             .posterImageURL(response.posterImageURL())
-            .cursor(CursorApiResponse.toCursorResponse(response.interestShowId(), response.interestedAt()))
             .build();
     }
 }

--- a/app/api/show-api/src/main/java/com/example/show/controller/dto/response/ShowPaginationApiParam.java
+++ b/app/api/show-api/src/main/java/com/example/show/controller/dto/response/ShowPaginationApiParam.java
@@ -2,15 +2,15 @@ package com.example.show.controller.dto.response;
 
 import com.example.show.service.dto.response.ShowPaginationServiceResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
 import lombok.Builder;
-import org.example.dto.response.CursorApiResponse;
 import org.example.util.DateTimeUtil;
 
 @Builder
 public record ShowPaginationApiParam(
 
-    @Schema(description = "조회한 데이터의 Cursor")
-    CursorApiResponse cursor,
+    @Schema(description = "공연 ID")
+    UUID id,
 
     @Schema(description = "공연 이름")
     String title,
@@ -30,7 +30,7 @@ public record ShowPaginationApiParam(
 
     public static ShowPaginationApiParam from(ShowPaginationServiceResponse response) {
         return ShowPaginationApiParam.builder()
-            .cursor(CursorApiResponse.toCursorId(response.id()))
+            .id(response.id())
             .title(response.title())
             .location(response.location())
             .posterImageURL(response.image())


### PR DESCRIPTION
## 😋 작업한 내용

- cursor를 data 목록에서 뺐습니다.

```java {
    "size": 1,
    "hasNext": false,
    "data": [
        {
            "id": "01919901-105d-b5b2-cbaf-912f20281ce8",
            "title": "OFFICIAL HIGE DANDISM REJOICE ASIA TOUR 2024 : 2024 오피셜히게단디즘 내한공연",
            "startAt": "2024-12-1",
            "endAt": "2024-12-1",
            "location": "일산 킨텍스 제1전시장 5홀",
            "posterImageURL": "https://showpot-s3.s3.ap-northeast-2.amazonaws.com/show/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-08-28%20%E1%84%8B%E1%85%A9%E1%84%92%E1%85%AE%209.37.40_1724848869198.png"
        }
    ],
    "cursor": {
        "id": "019205d7-b727-8af3-8f9e-1ffe5237fcef",
        "value": "2024-09-19T00:54:36.204"
    }
}

{
    "size": 1,
    "hasNext": false,
    "data": [
        {
            "id": "019194aa-d2fd-e29f-96c7-df9101dfd1b6",
            "title": "Post Malone If Y'all Weren't Here I'd Be Crying : 포스트말론 내한공연",
            "startAt": "2024-9-27",
            "endAt": "2024-9-27",
            "location": "여의도 KBS홀",
            "imageURL": "https://showpot-s3.s3.ap-northeast-2.amazonaws.com/show/%EB%8B%A4%EC%9A%B4%EB%A1%9C%EB%93%9C%20%281%29_1724936633293.jfif"
        }
    ],
    "cursor": {
        "id": "019194aa-d2fd-e29f-96c7-df9101dfd1b6",
        "value": null
    }
}
```
이런식입니당.

## 🙏 PR Point

- cursor 데이터가 없을 때에는 CursorApiResponse.noneCursor()가 나을까요 아님 그냥 null을 반환시킬까용?

## 👍 관련 이슈

- Resolved : #173


---